### PR TITLE
lint: ensure that format is always literal

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,34 @@
       {
         "selector": "MemberExpression[property.name='toString']",
         "message": "Use template literals instead of .toString()"
+      },
+      {
+        "selector": "CallExpression:matches([callee.name='format'], [callee.property.name='write'], [callee.property.name='block']):not(:matches([arguments.0.type='Literal'], [arguments.0.type='Identifier']:matches([arguments.0.name='fmt'], [arguments.0.name='close'])))",
+        "message": "Only literals or 'fmt' / 'close' identifiers are allowed as first format(), .write() and .block() argument (fmt)"
+      },
+      {
+        "selector": "CallExpression[callee.name='errorIf']:not([arguments.0.type='Literal'])",
+        "message": "Only literals are allowed as first errorIf() argument (fmt)"
+      },
+      {
+        "selector": "CallExpression[callee.name='maybeWrap']:not([arguments.1.type='Literal'][arguments.3.type='Literal'])",
+        "message": "Only literals are allowed as second and fourth maybeWrap() argument (fmt, close)"
+      },
+      {
+        "selector": "CallExpression[callee.property.name='block']:not(:matches([arguments.2.type='Literal'], [arguments.2.name='close']))",
+        "message": "Only literals or 'close' are allowed as third .block() argument (close)"
+      },
+      {
+        "selector": ":not(:matches([id.name='format'], [key.name='write'], [key.name='block'], [id.name='errorIf'], [id.name='maybeWrap'])) > [params] > Identifier:matches([name='fmt'], [name='close'])",
+        "message": "Identifiers 'fmt' / 'close' can be only defined as format(), .write(), .block(), errorIf() and maybeWrap() arguments"
+      },
+      {
+        "selector": "VariableDeclarator > .id:matches([name='fmt'], [name='close'])",
+        "message": "Identifiers 'fmt' / 'close' can be only defined as function arguments"
+      },
+      {
+        "selector": "VariableDeclarator > .id :matches([name='fmt'], [name='close'])",
+        "message": "Identifiers 'fmt' / 'close' can be only defined as function arguments"
       }
     ],
     "prefer-const": 2,


### PR DESCRIPTION
Probably the selectors are not optimal, but this should catch non-intended usage of format.

Runtime variables should never end up there, as that gets concatenated into the resulting source code bypassing `SafeString` logic. That should be allowed only for literal hard-coded strings.

e.g. `fun.write(somevar, whatever)` and <code>format(&#96;boo${somevar}&#96;)</code> now fail lint.