### PR TITLE
Only assign to module.exports once

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -764,5 +764,5 @@ const parser = function(schema, opts = {}) {
   return parse
 }
 
+Object.assign(validator, { validator, parser })
 module.exports = validator
-Object.assign(module.exports, { validator, parser })


### PR DESCRIPTION
This simplifies bundling and removes unneeded require wrapper in bundled code.