### PR TITLE
Re-implement toJayString for shared hasOwn

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -113,6 +113,7 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
     const name = buildName(location) // also checks for sanity, do not remove
     const { parent, keyval, keyname } = location
     if (parent) {
+      scope.hasOwn = functions.hasOwn
       if (keyval) {
         return format('%s !== undefined && hasOwn(%s, %j)', name, parent, keyval)
       } else if (keyname) {
@@ -127,7 +128,6 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
   // Since undefined is not a valid JSON value, we coerce to null and other checks will catch this
   fun.write('if (data === undefined) data = null')
   if (optIncludeErrors) fun.write('validate.errors = null')
-  fun.write('const hasOwn = Function.prototype.call.bind(Object.prototype.hasOwnProperty)')
   fun.write('let errors = 0')
 
   const getMeta = () => rootMeta.get(root) || {}

--- a/src/jaystring.js
+++ b/src/jaystring.js
@@ -3,8 +3,12 @@ const isArrowFnWithoutParensRegex = /^[^=]*=>/
 
 // Supports only functions and regexps, for scope
 
+const toJayString = Symbol.for('toJayString')
+
 function jaystring(item) {
   if (typeof item === 'function') {
+    if (item[toJayString]) return item[toJayString] // this is supported only for functions
+
     if (Object.getPrototypeOf(item) !== Function.prototype)
       throw new Error('Can not stringify a function with unexpected prototype')
 

--- a/src/scope-functions.js
+++ b/src/scope-functions.js
@@ -64,4 +64,8 @@ const unique = (array) => {
   return true
 }
 
-module.exports = { stringLength, isMultipleOf, deepEqual, unique }
+const hasOwn = Function.prototype.call.bind(Object.prototype.hasOwnProperty)
+// special handling for stringification
+hasOwn[Symbol.for('toJayString')] = 'Function.prototype.call.bind(Object.prototype.hasOwnProperty)'
+
+module.exports = { stringLength, isMultipleOf, deepEqual, unique, hasOwn }


### PR DESCRIPTION
Now `hasOwn` is created once per scope, and is added only when needed.

This approach can be reused for other methods.