### PR TITLE
Make list of known compare ops a set

### DIFF
--- a/src/safe-format.js
+++ b/src/safe-format.js
@@ -2,6 +2,8 @@
 
 class SafeString extends String {} // used for instanceof checks
 
+const compares = new Set(['<', '>', '<=', '>='])
+
 const format = (fmt, ...args) => {
   const res = fmt.replace(/%[%dscj]/g, (match) => {
     if (match === '%%') return '%'
@@ -15,7 +17,7 @@ const format = (fmt, ...args) => {
         if (val instanceof SafeString) return val
         throw new Error('Expected a safe string')
       case '%c':
-        if (['<', '>', '<=', '>='].includes(val)) return val
+        if (compares.has(val)) return val
         throw new Error('Expected a compare op')
       case '%j':
         if ([Infinity, -Infinity, NaN, undefined].includes(val)) return `${val}`


### PR DESCRIPTION
`Array#includes` is less reliable in some cases, let's use a `Set` in codegen.
This also uses an intermediate array, but only once and at require time.