### PR TITLE
verboseErrors handling improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,14 @@ console.log(validate(42)) // false
 
 ## Verbose mode shows more information about the source of the error
 
-When the `verbose` options is set to `true`, `@exodus/schemasafe` also outputs:
+When the `includeErrors` and `verboseErrors` options are set to `true`, `@exodus/schemasafe` also
+outputs:
 
+- `schemaPath`: a JSON pointer string as an URI fragment indicating which sub-schema failed, e.g.
+  `#/properties/item/type`
+- `dataPath`: a JSON pointer string as an URI fragment indicating which property of the object
+  failed validation, e.g. `#/item`
 - `value`: The data value that caused the error
-- `schemaPath`: a JSON pointer string as an URI fragment indicating which sub-schema failed, e.g. `#/type`
 
 ```js
 const schema = {

--- a/README.md
+++ b/README.md
@@ -29,10 +29,6 @@ const validate = validator({
 
 console.log('should be valid', validate({ hello: 'world' }))
 console.log('should not be valid', validate({}))
-
-// get the last list of errors by checking validate.errors
-// the following will print [{field: 'data.hello', message: 'is required'}]
-console.log(validate.errors)
 ```
 
 ## Custom formats
@@ -98,12 +94,10 @@ const validate = validator(schema, {
 
 validate({ hello: 100 });
 console.log(validate.errors)
-// [ { field: 'data["hello"]',
-//     message: 'is the wrong type',
-//     type: 'string',
+// [ { message: 'is the wrong type',
 //     schemaPath: '#/properties/hello',
+//     dataPath: '#/hello',
 //     value: 100 } ]
-
 ```
 
 ## Generate Modules

--- a/src/index.js
+++ b/src/index.js
@@ -182,7 +182,7 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
         const errorObj = { message: msg, schemaPath: functions.toPointer(schemaPath) }
         if (verboseErrors) scope.toPointer = functions.toPointer
         const errorJS = verboseErrors
-          ? format('{ ...%j, field: %s, value: %s }', errorObj, buildPath(prop), buildName(prop))
+          ? format('{ ...%j, dataPath: %s, value: %s }', errorObj, buildPath(prop), buildName(prop))
           : format('%j', errorObj)
         if (allErrors) {
           fun.write('if (validate.errors === null) validate.errors = []')

--- a/src/index.js
+++ b/src/index.js
@@ -860,7 +860,7 @@ const parser = function(schema, opts = {}) {
     const data = JSON.parse(src)
     if (validate(data)) return data
     const message = validate.errors
-      ? validate.errors.map((err) => `${err.field} ${err.message}`).join('\n')
+      ? validate.errors.map((err) => `${err.schemaPath} ${err.message}`).join('\n')
       : ''
     const error = new Error(`JSON validation error${message ? `: ${message}` : ''}`)
     error.errors = validate.errors

--- a/src/pointer.js
+++ b/src/pointer.js
@@ -1,10 +1,5 @@
 'use strict'
 
-function toPointer(path) {
-  if (path.length === 0) return '#'
-  return `#/${path.map((part) => `${part}`.replace(/~/g, '~0').replace(/\//g, '~1')).join('/')}`
-}
-
 function untilde(string) {
   if (!string.includes('~')) return string
   return string.replace(/~[01]/g, (match) => {
@@ -103,4 +98,4 @@ function resolveReference(root, additionalSchemas, ref, base = '') {
   return results
 }
 
-module.exports = { toPointer, get, joinPath, resolveReference }
+module.exports = { get, joinPath, resolveReference }

--- a/src/scope-functions.js
+++ b/src/scope-functions.js
@@ -68,4 +68,10 @@ const hasOwn = Function.prototype.call.bind(Object.prototype.hasOwnProperty)
 // special handling for stringification
 hasOwn[Symbol.for('toJayString')] = 'Function.prototype.call.bind(Object.prototype.hasOwnProperty)'
 
-module.exports = { stringLength, isMultipleOf, deepEqual, unique, hasOwn }
+// Used for error generation
+function toPointer(path) {
+  if (path.length === 0) return '#'
+  return `#/${path.map((part) => `${part}`.replace(/~/g, '~0').replace(/\//g, '~1')).join('/')}`
+}
+
+module.exports = { stringLength, isMultipleOf, deepEqual, unique, hasOwn, toPointer }

--- a/test/data-path.js
+++ b/test/data-path.js
@@ -1,0 +1,55 @@
+'use strict'
+
+const tape = require('tape')
+const { validator } = require('../')
+
+tape('dataPath', (t) => {
+  const schema = {
+    properties: {
+      arr: {
+        items: {
+          additionalProperties: { type: 'string' },
+          propertyNames: { minLength: 2 },
+        },
+      },
+    },
+  }
+  const validate = validator(schema, { includeErrors: true, verboseErrors: true })
+
+  const checkError = (data, schemaPath, dataPath, message) => {
+    t.deepEqual(validate(data), false, `should have failed: ${message}`)
+    t.deepEqual(validate.errors[0].schemaPath, schemaPath, `schemaPath for ${message}`)
+    t.deepEqual(validate.errors[0].dataPath, dataPath, `dataPath for ${message}`)
+  }
+
+  t.ok(validate({ arr: [] }), 'valid empty array passes')
+  t.ok(validate({ arr: [{}] }), 'valid empty item in array passes')
+  t.ok(validate({ arr: [{ foo: 'bar' }] }), 'valid passes')
+
+  checkError(
+    { arr: [{ foo: 2 }] },
+    '#/properties/arr/items/additionalProperties',
+    '#/arr/0/foo',
+    'invalid type for #0'
+  )
+  checkError(
+    { arr: [{ x: 'bar' }] },
+    '#/properties/arr/items/propertyNames',
+    '#/arr/0/x',
+    'invalid name for #0'
+  )
+  checkError(
+    { arr: [{}, { foo: 2 }] },
+    '#/properties/arr/items/additionalProperties',
+    '#/arr/1/foo',
+    'invalid type for #1'
+  )
+  checkError(
+    { arr: [{}, { x: 'bar' }] },
+    '#/properties/arr/items/propertyNames',
+    '#/arr/1/x',
+    'invalid name for #1'
+  )
+
+  t.end()
+})

--- a/test/misc.js
+++ b/test/misc.js
@@ -48,19 +48,19 @@ tape('allErrors/false', function(t) {
       },
       required: ['x', 'y'],
     },
-    { includeErrors: true, allErrors: false }
+    { includeErrors: true, verboseErrors: true, allErrors: false }
   )
   t.notOk(validate({}), 'should be invalid')
   t.strictEqual(validate.errors.length, 1)
-  t.strictEqual(validate.errors[0].field, 'data["x"]')
+  t.strictEqual(validate.errors[0].field, '#/x')
   t.strictEqual(validate.errors[0].message, 'is required')
   t.notOk(validate({ x: 'string' }), 'should be invalid')
   t.strictEqual(validate.errors.length, 1)
-  t.strictEqual(validate.errors[0].field, 'data["y"]')
+  t.strictEqual(validate.errors[0].field, '#/y')
   t.strictEqual(validate.errors[0].message, 'is required')
   t.notOk(validate({ x: 'string', y: 'value' }), 'should be invalid')
   t.strictEqual(validate.errors.length, 1)
-  t.strictEqual(validate.errors[0].field, 'data["x"]')
+  t.strictEqual(validate.errors[0].field, '#/x')
   t.strictEqual(validate.errors[0].message, 'is the wrong type')
   t.end()
 })
@@ -76,23 +76,23 @@ tape('allErrors/true', function(t) {
       },
       required: ['x', 'y'],
     },
-    { includeErrors: true, allErrors: true }
+    { includeErrors: true, verboseErrors: true, allErrors: true }
   )
   t.notOk(validate({}), 'should be invalid')
   t.strictEqual(validate.errors.length, 2)
-  t.strictEqual(validate.errors[0].field, 'data["x"]')
+  t.strictEqual(validate.errors[0].field, '#/x')
   t.strictEqual(validate.errors[0].message, 'is required')
-  t.strictEqual(validate.errors[1].field, 'data["y"]')
+  t.strictEqual(validate.errors[1].field, '#/y')
   t.strictEqual(validate.errors[1].message, 'is required')
   t.notOk(validate({ x: 'string' }), 'should be invalid')
   t.strictEqual(validate.errors.length, 2)
-  t.strictEqual(validate.errors[0].field, 'data["y"]')
+  t.strictEqual(validate.errors[0].field, '#/y')
   t.strictEqual(validate.errors[0].message, 'is required')
-  t.strictEqual(validate.errors[1].field, 'data["x"]')
+  t.strictEqual(validate.errors[1].field, '#/x')
   t.strictEqual(validate.errors[1].message, 'is the wrong type')
   t.notOk(validate({ x: 'string', y: 'value' }), 'should be invalid')
   t.strictEqual(validate.errors.length, 1)
-  t.strictEqual(validate.errors[0].field, 'data["x"]')
+  t.strictEqual(validate.errors[0].field, '#/x')
   t.strictEqual(validate.errors[0].message, 'is the wrong type')
   t.ok(validate({ x: 1, y: 'value' }), 'should be invalid')
   t.end()
@@ -112,10 +112,7 @@ tape('additional props', function(t) {
 
   t.ok(validate({}))
   t.notOk(validate({ foo: 'bar' }))
-  t.ok(
-    validate.errors[0].value === 'data.foo',
-    'should output the property not allowed in verbose mode'
-  )
+  t.ok(validate.errors[0].value === 'bar', 'should output the property not allowed in verbose mode')
   t.end()
 })
 
@@ -393,11 +390,11 @@ tape('nested required array decl', function(t) {
     required: ['x'],
   }
 
-  const validate = validator(schema, { includeErrors: true })
+  const validate = validator(schema, { includeErrors: true, verboseErrors: true })
 
   t.ok(validate({ x: {} }), 'should be valid')
   t.notOk(validate({}), 'should not be valid')
-  t.strictEqual(validate.errors[0].field, 'data["x"]', 'should output the missing field')
+  t.strictEqual(validate.errors[0].field, '#/x', 'should output the missing field')
   t.end()
 })
 
@@ -447,8 +444,8 @@ tape('additional props in verbose mode', function(t) {
 
   t.strictEqual(
     validate.errors[0].value,
-    'data["hello world"].bar',
-    'should output the path to the additional prop in the error'
+    'string',
+    'should output the value of the additional prop in the error'
   )
   t.end()
 })

--- a/test/misc.js
+++ b/test/misc.js
@@ -52,15 +52,15 @@ tape('allErrors/false', function(t) {
   )
   t.notOk(validate({}), 'should be invalid')
   t.strictEqual(validate.errors.length, 1)
-  t.strictEqual(validate.errors[0].field, '#/x')
+  t.strictEqual(validate.errors[0].dataPath, '#/x')
   t.strictEqual(validate.errors[0].message, 'is required')
   t.notOk(validate({ x: 'string' }), 'should be invalid')
   t.strictEqual(validate.errors.length, 1)
-  t.strictEqual(validate.errors[0].field, '#/y')
+  t.strictEqual(validate.errors[0].dataPath, '#/y')
   t.strictEqual(validate.errors[0].message, 'is required')
   t.notOk(validate({ x: 'string', y: 'value' }), 'should be invalid')
   t.strictEqual(validate.errors.length, 1)
-  t.strictEqual(validate.errors[0].field, '#/x')
+  t.strictEqual(validate.errors[0].dataPath, '#/x')
   t.strictEqual(validate.errors[0].message, 'is the wrong type')
   t.end()
 })
@@ -80,19 +80,19 @@ tape('allErrors/true', function(t) {
   )
   t.notOk(validate({}), 'should be invalid')
   t.strictEqual(validate.errors.length, 2)
-  t.strictEqual(validate.errors[0].field, '#/x')
+  t.strictEqual(validate.errors[0].dataPath, '#/x')
   t.strictEqual(validate.errors[0].message, 'is required')
-  t.strictEqual(validate.errors[1].field, '#/y')
+  t.strictEqual(validate.errors[1].dataPath, '#/y')
   t.strictEqual(validate.errors[1].message, 'is required')
   t.notOk(validate({ x: 'string' }), 'should be invalid')
   t.strictEqual(validate.errors.length, 2)
-  t.strictEqual(validate.errors[0].field, '#/y')
+  t.strictEqual(validate.errors[0].dataPath, '#/y')
   t.strictEqual(validate.errors[0].message, 'is required')
-  t.strictEqual(validate.errors[1].field, '#/x')
+  t.strictEqual(validate.errors[1].dataPath, '#/x')
   t.strictEqual(validate.errors[1].message, 'is the wrong type')
   t.notOk(validate({ x: 'string', y: 'value' }), 'should be invalid')
   t.strictEqual(validate.errors.length, 1)
-  t.strictEqual(validate.errors[0].field, '#/x')
+  t.strictEqual(validate.errors[0].dataPath, '#/x')
   t.strictEqual(validate.errors[0].message, 'is the wrong type')
   t.ok(validate({ x: 1, y: 'value' }), 'should be invalid')
   t.end()
@@ -394,7 +394,7 @@ tape('nested required array decl', function(t) {
 
   t.ok(validate({ x: {} }), 'should be valid')
   t.notOk(validate({}), 'should not be valid')
-  t.strictEqual(validate.errors[0].field, '#/x', 'should output the missing field')
+  t.strictEqual(validate.errors[0].dataPath, '#/x', 'should output the missing field')
   t.end()
 })
 
@@ -480,7 +480,7 @@ tape.skip('field shows item index in arrays', function(t) {
   validate([[{ foo: 'test' }, { foo: 'test' }], [{ foo: 'test' }, { baz: 'test' }]])
 
   t.strictEqual(
-    validate.errors[0].field,
+    validate.errors[0].dataPath,
     'data.1.1.foo',
     'should output the field with specific index of failing item in the error'
   )

--- a/test/misc.js
+++ b/test/misc.js
@@ -458,8 +458,7 @@ tape('Date.now() is an integer', function(t) {
   t.end()
 })
 
-// Due to altered (safer) formatName function, this does not work
-tape.skip('field shows item index in arrays', function(t) {
+tape('field shows item index in arrays', function(t) {
   const schema = {
     type: 'array',
     items: {
@@ -475,13 +474,13 @@ tape.skip('field shows item index in arrays', function(t) {
     },
   }
 
-  const validate = validator(schema)
+  const validate = validator(schema, { includeErrors: true, verboseErrors: true })
 
   validate([[{ foo: 'test' }, { foo: 'test' }], [{ foo: 'test' }, { baz: 'test' }]])
 
   t.strictEqual(
     validate.errors[0].dataPath,
-    'data.1.1.foo',
+    '#/1/1/foo',
     'should output the field with specific index of failing item in the error'
   )
   t.end()


### PR DESCRIPTION
To unbreak `field` property in errors.
Also, `field` is renamed to `dataPath`.
Also, fixes `value`.

This only applies to `verboseErrors`.

Before: `{ field: 'data[favoriteSingleDigitWholeNumbers][j]' }`
After: `{ dataPath: '#/favoriteSingleDigitWholeNumbers/2' }`