### PR TITLE
Reference resolution improvements

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -273,7 +273,7 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
     }
 
     if (node.$ref) {
-      const resolved = resolveReference(root, schemas || {}, joinPath(basePath(), node.$ref))
+      const resolved = resolveReference(root, schemas || {}, node.$ref, basePath())
       const [sub, subRoot, path] = resolved[0] || []
       if (sub || sub === false) {
         let n = refCache.get(sub)

--- a/test/misc.js
+++ b/test/misc.js
@@ -316,7 +316,7 @@ tape('#toJSON()', function(t) {
 tape('external schemas', function(t) {
   const ext = { type: 'string' }
   const schema = {
-    $ref: '#ext',
+    $ref: 'ext#',
   }
 
   const validate = validator(schema, { schemas: { ext: ext } })


### PR DESCRIPTION
* Fix refs to self if $id is present
* Fix minor issues
* Drop support for is-my-json-valid non-standard refs
* Minor code cleanup

Now we are able to parse schemas describing JSON Schema.