### PR TITLE
coverage: ignore unreachable code paths

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,7 @@ const buildName = ({ name, parent, keyval, keyname }) => {
   } else if (parent && keyname) {
     return format('%s[%s]', parent, keyname)
   }
+  /* c8 ignore next */
   throw new Error('Unreachable')
 }
 

--- a/src/safe-format.js
+++ b/src/safe-format.js
@@ -23,6 +23,7 @@ const format = (fmt, ...args) => {
         if ([Infinity, -Infinity, NaN, undefined].includes(val)) return `${val}`
         return JSON.stringify(val)
     }
+    /* c8 ignore next */
     throw new Error(`Unreachable`)
   })
   if (args.length !== 0) throw new Error('Unexpected arguments count')


### PR DESCRIPTION
Those are safety guards that make sure that unexpected things don't happen there. They are supposed to be never reachable, on any input, so we exclude them from coverage.

Before:
![Screenshot_20200614_062649](https://user-images.githubusercontent.com/291301/84583982-0a0fcb00-ae08-11ea-93bb-679224a39b8a.png)


After:
![Screenshot_20200614_062710](https://user-images.githubusercontent.com/291301/84583998-172cba00-ae08-11ea-9e33-17ec7a6ea28b.png)
