### PR TITLE
Enforce strict mode semantics on all files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,7 @@
 {
+  "parserOptions": {
+    "sourceType": "script"
+  },
   "env": {
     "browser": true,
     "node": true
@@ -45,6 +48,7 @@
         "message": "Identifiers 'fmt' / 'close' can be only defined as function arguments"
       }
     ],
+    "strict": 2,
     "prefer-const": 2,
     "prefer-template": 2,
     "no-var": 2

--- a/src/generate-function.js
+++ b/src/generate-function.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { format } = require('./safe-format')
 const jaystring = require('./jaystring')
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { format, safe, safeand, safeor } = require('./safe-format')
 const genfun = require('./generate-function')
 const { toPointer, resolveReference, joinPath } = require('./pointer')

--- a/src/jaystring.js
+++ b/src/jaystring.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const isArrowFnWithParensRegex = /^\([^)]*\) *=>/
 const isArrowFnWithoutParensRegex = /^[^=]*=>/
 

--- a/src/known-keywords.js
+++ b/src/known-keywords.js
@@ -1,3 +1,5 @@
+'use strict'
+
 module.exports = [
   '$schema', // version
   ...['id', '$id', '$ref', 'definitions', '$defs'], // pointers

--- a/test/fixtures/cosmic.js
+++ b/test/fixtures/cosmic.js
@@ -1,4 +1,6 @@
-exports.valid = {
+'use strict'
+
+const valid = {
   fullName: 'John Doe',
   age: 47,
   state: 'Massachusetts',
@@ -42,7 +44,7 @@ exports.valid = {
   ],
 }
 
-exports.invalid = {
+const invalid = {
   fullName: null,
   age: -1,
   state: 47,
@@ -58,7 +60,7 @@ exports.invalid = {
   emailAddresses: [],
 }
 
-exports.schema = {
+const schema = {
   // from cosmic thingy
   type: 'object',
   additionalProperties: false,
@@ -109,3 +111,5 @@ exports.schema = {
     },
   },
 }
+
+module.exports = { valid, invalid, schema }

--- a/test/json-schema.js
+++ b/test/json-schema.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const tape = require('tape')
 const fs = require('fs')
 const path = require('path')

--- a/test/misc.js
+++ b/test/misc.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const tape = require('tape')
 const cosmic = require('./fixtures/cosmic')
 const validator = require('../')

--- a/test/options.js
+++ b/test/options.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const tape = require('tape')
 const validator = require('../')
 

--- a/test/parser.js
+++ b/test/parser.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const tape = require('tape')
 const { validator, parser } = require('../')
 

--- a/test/regressions/broken-required.js
+++ b/test/regressions/broken-required.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const tape = require('tape')
 const validator = require('../../')
 

--- a/test/regressions/contains-errors.js
+++ b/test/regressions/contains-errors.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const tape = require('tape')
 const validator = require('../../')
 

--- a/test/regressions/numbers.js
+++ b/test/regressions/numbers.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const tape = require('tape')
 const validator = require('../../')
 

--- a/test/regressions/unique.js
+++ b/test/regressions/unique.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const tape = require('tape')
 const validator = require('../../')
 

--- a/test/safe-regex.js
+++ b/test/safe-regex.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const tape = require('tape')
 const safeRegex = require('safe-regex')
 

--- a/test/schema-path.js
+++ b/test/schema-path.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const tape = require('tape')
 const validator = require('../')
 const { get } = require('../src/pointer')

--- a/test/tools/test-module.js
+++ b/test/tools/test-module.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const path = require('path')
 const orig = require('../..')
 


### PR DESCRIPTION
It changes e.g. Object.freeze behavior -- outside of strict mode, assigning properties to frozen objects silently swallows errors, while in strict mode, it throws.