### PR TITLE
Export an { validator, parser } object

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install --save @exodus/schemasafe
 Simply pass a schema to compile it
 
 ```js
-const validator = require('@exodus/schemasafe')
+const { validator } = require('@exodus/schemasafe')
 
 const validate = validator({
   type: 'object',
@@ -111,7 +111,7 @@ console.log(validate.errors)
 To compile a validator function to an IIFE, call `validate.toModule()`:
 
 ```js
-const validator = require('@exodus/schemasafe')
+const { validator } = require('@exodus/schemasafe')
 
 const schema = {
   type: 'string',

--- a/src/index.js
+++ b/src/index.js
@@ -764,5 +764,4 @@ const parser = function(schema, opts = {}) {
   return parse
 }
 
-Object.assign(validator, { validator, parser })
-module.exports = validator
+module.exports = { validator, parser }

--- a/test/json-schema.js
+++ b/test/json-schema.js
@@ -1,7 +1,7 @@
 const tape = require('tape')
 const fs = require('fs')
 const path = require('path')
-const validator = require('../')
+const { validator } = require('../')
 
 // these tests require lax mode
 const unsafe = new Set([

--- a/test/misc.js
+++ b/test/misc.js
@@ -1,6 +1,6 @@
 const tape = require('tape')
 const cosmic = require('./fixtures/cosmic')
-const validator = require('../')
+const { validator } = require('../')
 
 tape('simple', function(t) {
   const schema = {

--- a/test/options.js
+++ b/test/options.js
@@ -1,5 +1,5 @@
 const tape = require('tape')
-const validator = require('../')
+const { validator } = require('../')
 
 tape('unknown', (t) => {
   t.throws(() => validator({}, { whatever: 1 }), /option.*whatever/)

--- a/test/regressions/broken-required.js
+++ b/test/regressions/broken-required.js
@@ -1,5 +1,5 @@
 const tape = require('tape')
-const validator = require('../../')
+const { validator } = require('../../')
 
 const runWithOptions = (t, opts) => {
   t.notOk(validator({ required: [], uniqueItems: true }, opts)([1, 1]), 'required + uniqueItems')

--- a/test/regressions/contains-errors.js
+++ b/test/regressions/contains-errors.js
@@ -1,5 +1,5 @@
 const tape = require('tape')
-const validator = require('../../')
+const { validator } = require('../../')
 
 tape('contains does not pollute errors', (t) => {
   const validate = validator({ type: 'array', contains: { const: 2 } }, { includeErrors: true })

--- a/test/regressions/numbers.js
+++ b/test/regressions/numbers.js
@@ -1,5 +1,5 @@
 const tape = require('tape')
-const validator = require('../../')
+const { validator } = require('../../')
 
 tape('number', (t) => {
   const validate = validator({ type: 'number' })

--- a/test/regressions/unique.js
+++ b/test/regressions/unique.js
@@ -1,5 +1,5 @@
 const tape = require('tape')
-const validator = require('../../')
+const { validator } = require('../../')
 
 tape('unique is not confused by type mismatch', (t) => {
   const validate = validator({ type: 'array', uniqueItems: true })

--- a/test/schema-path.js
+++ b/test/schema-path.js
@@ -1,5 +1,5 @@
 const tape = require('tape')
-const validator = require('../')
+const { validator } = require('../')
 const { get } = require('../src/pointer')
 
 const target = Symbol('target')

--- a/test/tools/test-module.js
+++ b/test/tools/test-module.js
@@ -26,5 +26,4 @@ const wrap = (orig) =>
 const validator = wrap(validatorOrig)
 const parser = wrap(parserOrig)
 
-indexModule.exports = validator
-Object.assign(indexModule.exports, { validator, parser })
+indexModule.exports = { validator, parser }


### PR DESCRIPTION
Instead of exporting a validator function with properties on it.

This is more clean, and we don't want to make validator the de-facto default.

This is a breaking change.