### PR TITLE
Implement requireStringValidation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,6 +79,7 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
     dryRun = false,
     allowUnusedKeywords = opts.mode === 'lax',
     requireValidation = opts.mode === 'strong',
+    requireStringValidation = opts.mode === 'strong',
     complexityChecks = opts.mode === 'strong',
     $schemaDefault = null,
     formats: optFormats = {},
@@ -97,8 +98,8 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
     throw new Error(`Unknown options: ${Object.keys(unknown).join(', ')}`)
 
   if (!['strong', 'lax', 'default'].includes(mode)) throw new Error(`Invalid mode: ${mode}`)
-  if (mode === 'strong' && (!requireValidation || !complexityChecks))
-    throw new Error('Strong mode demands requireValidation and complexityChecks')
+  if (mode === 'strong' && (!requireValidation || !requireStringValidation || !complexityChecks))
+    throw new Error('Strong mode demands require(String)Validation and complexityChecks')
   if (mode === 'strong' && (weakFormats || allowUnusedKeywords))
     throw new Error('Strong mode forbids weakFormats and allowUnusedKeywords')
 
@@ -348,7 +349,7 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
 
     const enforceRegex = (pattern, target = node) => {
       enforce(typeof pattern === 'string', 'Invalid pattern:', pattern)
-      if (requireValidation)
+      if (requireValidation || requireStringValidation)
         enforce(/^\^.*\$$/.test(pattern), 'Should start with ^ and end with $:', pattern)
       if (complexityChecks && (pattern.match(/[{+*]/g) || []).length > 1)
         enforce(target.maxLength !== undefined, 'maxLength should be specified for:', pattern)
@@ -430,9 +431,13 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
 
       if (node.pattern) {
         enforceRegex(node.pattern)
-        const p = patterns(node.pattern)
-        errorIf('!%s.test(%s)', [p, name], 'pattern mismatch')
+        if (node.pattern !== '^[\\s\\S]*$' && node.pattern !== '^[\\S\\s]*$') {
+          const p = patterns(node.pattern)
+          errorIf('!%s.test(%s)', [p, name], 'pattern mismatch')
+        }
         consume('pattern', 'string')
+      } else if (typeApplicable('string') && requireStringValidation && !node.format) {
+        fail('pattern or format must be specified for strings, use pattern: ^[\\s\\S]*$ to opt-out')
       }
     }
 

--- a/test/parser.js
+++ b/test/parser.js
@@ -16,7 +16,7 @@ tape('default is strong mode', (t) => {
 
   t.throws(() => {
     parser({}, { requireValidation: false })
-  }, /Strong mode demands requireValidation/)
+  }, /Strong mode demands/)
 
   t.doesNotThrow(() => {
     parser({}, { mode: 'default' })
@@ -28,7 +28,7 @@ tape('default is strong mode', (t) => {
 tape('parser works correctly', (t) => {
   let parsed
 
-  t.strictEqual(typeof parser({ type: 'string' }), 'function', 'returns a function')
+  t.strictEqual(typeof parser({ type: 'string', format: 'date' }), 'function', 'returns a function')
 
   t.throws(() => {
     parser({ type: 'integer' })('{}')


### PR DESCRIPTION
Enforces at least one of `format` or `pattern` to be present on strings.

Enabled by default in strong mode.
Opt-out is possible via no-op regex as `pattern`, i.e. `^[\s\S]*$`.

No-op regex is specifically excluded from the generated code (as it always passes).