### PR TITLE
add jsonCheck option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -80,6 +80,7 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
     allowUnusedKeywords = opts.mode === 'lax',
     requireValidation = opts.mode === 'strong',
     complexityChecks = opts.mode === 'strong',
+    jsonCheck = false, // disabled by default, it's assumed that data is from JSON.parse
     $schemaDefault = null,
     formats: optFormats = {},
     weakFormats = opts.mode !== 'strong',
@@ -296,6 +297,12 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
       fun.write('if (%s) {', present(current))
     }
 
+    if (jsonCheck) {
+      // this check has to be done only after existance check and before all other checks
+      scope.deepEqual = functions.deepEqual
+      errorIf('!deepEqual(%s, JSON.parse(JSON.stringify(%s)))', [name, name], 'not JSON compatible')
+    }
+
     if (node.$ref) {
       const resolved = resolveReference(root, schemas || {}, node.$ref, basePath())
       const [sub, subRoot, path] = resolved[0] || []
@@ -306,7 +313,8 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
           refCache.set(sub, n)
           let fn = null // resolve cyclic dependencies
           scope[n] = (...args) => fn(...args)
-          fn = compile(sub, subRoot, { ...opts, includeErrors: false }, scope, path)
+          const override = { includeErrors: false, jsonCheck: false }
+          fn = compile(sub, subRoot, { ...opts, ...override }, scope, path)
           scope[n] = fn
         }
         errorIf('!%s(%s)', [n, name], 'referenced schema does not match')

--- a/test/misc.js
+++ b/test/misc.js
@@ -491,3 +491,30 @@ tape.skip('field shows item index in arrays', function(t) {
   )
   t.end()
 })
+
+tape('jsonCheck option', function(t) {
+  const schema = {
+    type: 'object',
+    required: ['bar'],
+    properties: {
+      bar: {
+        type: 'boolean',
+      },
+    },
+  }
+
+  class Foo {
+    constructor() {
+      this.bar = true
+    }
+  }
+
+  t.ok(validator(schema)(new Foo()), 'non-JSON is OK without jsonCheck')
+
+  const validate = validator(schema, { jsonCheck: true, includeErrors: true })
+  t.notOk(validate(new Foo()), 'non-JSON fails with jsonCheck')
+  const [error] = validate.errors
+  t.is(error.message, 'not JSON compatible', 'correct error message')
+
+  t.end()
+})


### PR DESCRIPTION
It's disabled by default as it's assumed that all data comes from `JSON.parse`.

Could be useful otherwise to guarantee that input is JSON-compatible.