### PR TITLE
Simplify type validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,16 +128,16 @@ const validate = validator(schema, { formats })
 console.log(validate.toModule())
 /** Prints:
  * (function() {
+ * 'use strict'
  * const format0 = (value) => /^0x[0-9A-Fa-f]*$/.test(value);
  * return (function validate(data) {
  *   if (data === undefined) data = null
  *   let errors = 0
  *   if (!(typeof data === "string")) {
  *     return false
- *   } else {
- *     if (!format0(data)) {
- *       return false
- *     }
+ *   }
+ *   if (!format0(data)) {
+ *     return false
  *   }
  *   return errors === 0
  * })})();

--- a/src/index.js
+++ b/src/index.js
@@ -755,23 +755,17 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
 
     const typeValidate = safeor(...typeArray.map((t) => types.get(t)(name)))
     const needTypeValidation = `${typeValidate}` !== 'true'
-    if (needTypeValidation) {
-      fun.write('if (!(%s)) {', typeValidate)
-      error('is the wrong type')
-    }
+    if (needTypeValidation) errorIf('!(%s)', [typeValidate], 'is the wrong type')
     if (type) consume('type', 'string', 'array')
 
-    // If type validation was needed, we should wrap this inside an else clause.
-    // No need to close, type validation would always close at the end if it's used.
-    maybeWrap(needTypeValidation, '} else {', [], '', () => {
+    // If type validation was needed, wrap this inside an else clause.
+    maybeWrap(needTypeValidation, 'else {', [], '}', () => {
       typeWrap(checkNumbers, ['number', 'integer'], types.get('number')(name))
       typeWrap(checkStrings, ['string'], types.get('string')(name))
       typeWrap(checkArrays, ['array'], types.get('array')(name))
       typeWrap(checkObjects, ['object'], types.get('object')(name))
       checkGeneric()
     })
-
-    if (needTypeValidation) fun.write('}') // type check
 
     finish()
   }

--- a/src/index.js
+++ b/src/index.js
@@ -758,8 +758,8 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
     if (needTypeValidation) errorIf('!(%s)', [typeValidate], 'is the wrong type')
     if (type) consume('type', 'string', 'array')
 
-    // If type validation was needed, wrap this inside an else clause.
-    maybeWrap(needTypeValidation, 'else {', [], '}', () => {
+    // If type validation was needed and did not return early, wrap this inside an else clause.
+    maybeWrap(needTypeValidation && allErrors, 'else {', [], '}', () => {
       typeWrap(checkNumbers, ['number', 'integer'], types.get('number')(name))
       typeWrap(checkStrings, ['string'], types.get('string')(name))
       typeWrap(checkArrays, ['array'], types.get('array')(name))


### PR DESCRIPTION
1. Simplify type validation `else {}` wrap
    
    This makes code generate `}\n else {` instead of `} else {` on type check, but it makes the generator logic easier.

2. Unwrap `else{}` if type validation returned early
    
    If `allErrors` is false, type validation always returns on failed type check.
    In that case, we don't need to wrap code under it in `else { }`.

3. Generated toModule() result in Readme updated accordingly.


