### PR TITLE
Fast track empty schema nodes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -211,6 +211,11 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
     for (const key of Object.keys(node))
       enforce(KNOWN_KEYWORDS.includes(key) || allowUnusedKeywords, 'Keyword not supported:', key)
 
+    if (Object.keys(node).length === 0) {
+      enforceValidation('empty rules node encountered')
+      return // nothing to validate here, basically the same as node === true
+    }
+
     const unused = new Set(Object.keys(node))
     const consume = (prop, ...ruleTypes) => {
       enforce(unused.has(prop), 'Unexpected double consumption:', prop)


### PR DESCRIPTION
Avoids generating useless empty `if (!undefined) {}` blocks.

E.g. on JSON Schema draft6 schema:
```diff
26,27d25
<     if (data["default"] !== undefined && hasOwn(data, "default")) {
<     }
30,33d27
<       for (let i = 0; i < data["examples"].length; i++) {
<         if (data["examples"][i] !== undefined && hasOwn(data["examples"], i)) {
<         }
<       }
159,160d152
<     }
<     if (data["const"] !== undefined && hasOwn(data, "const")) {
```