### PR TITLE
Harden present() check

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -131,13 +131,12 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
   const present = (location) => {
     const name = buildName(location) // also checks for sanity, do not remove
     const { parent, keyval, keyname } = location
-    if (parent) {
+    if (parent && keyname) {
       scope.hasOwn = functions.hasOwn
-      if (keyval) {
-        return format('%s !== undefined && hasOwn(%s, %j)', name, parent, keyval)
-      } else if (keyname) {
-        return format('%s !== undefined && hasOwn(%s, %s)', name, parent, keyname)
-      }
+      return format('%s !== undefined && hasOwn(%s, %s)', name, parent, keyname)
+    } else if (parent && keyval !== undefined) {
+      scope.hasOwn = functions.hasOwn
+      return format('%s !== undefined && hasOwn(%s, %j)', name, parent, keyval)
     }
     return format('%s !== undefined', name)
   }


### PR DESCRIPTION
```
    Fix keyval check in present()
    
    It might be 0 in arrays.
```
```
    Fast-track top-level boolean false
    
    This allows to harden present() check.
```

Due to this check being slow (and done twice in some edge cases), I will introduce some exceptions there after this PR lands.
This is why code is currently organized that way -- i.e. separate branches for `keyname` and `keyval`.