### PR TITLE
Post-process JSON.stringify to escape u2028 and u2029

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,7 +16,7 @@
     "no-restricted-syntax": [
       2,
       {
-        "selector": "MemberExpression[property.name='toString']",
+        "selector": "CallExpression[callee.property.name='toString']:not(:matches([arguments.0]))",
         "message": "Use template literals instead of .toString()"
       },
       {

--- a/src/safe-format.js
+++ b/src/safe-format.js
@@ -3,6 +3,14 @@
 class SafeString extends String {} // used for instanceof checks
 
 const compares = new Set(['<', '>', '<=', '>='])
+const escapeCode = (code) => `\\u${code.toString(16).padStart(4, '0')}`
+
+// Supports simple js vaiables only, i.e. constants and JSON-stringifiable
+const jsval = (val) => {
+  if ([Infinity, -Infinity, NaN, undefined].includes(val)) return `${val}`
+  // https://v8.dev/features/subsume-json#security, e.g. {'\u2028':0} on Node.js 8
+  return JSON.stringify(val).replace(/[\u2028\u2029]/g, (char) => escapeCode(char.charCodeAt(0)))
+}
 
 const format = (fmt, ...args) => {
   const res = fmt.replace(/%[%dscj]/g, (match) => {
@@ -20,8 +28,7 @@ const format = (fmt, ...args) => {
         if (compares.has(val)) return val
         throw new Error('Expected a compare op')
       case '%j':
-        if ([Infinity, -Infinity, NaN, undefined].includes(val)) return `${val}`
-        return JSON.stringify(val)
+        return jsval(val)
     }
     /* c8 ignore next */
     throw new Error(`Unreachable`)

--- a/src/safe-format.js
+++ b/src/safe-format.js
@@ -5,7 +5,7 @@ class SafeString extends String {} // used for instanceof checks
 const compares = new Set(['<', '>', '<=', '>='])
 const escapeCode = (code) => `\\u${code.toString(16).padStart(4, '0')}`
 
-// Supports simple js vaiables only, i.e. constants and JSON-stringifiable
+// Supports simple js variables only, i.e. constants and JSON-stringifiable
 const jsval = (val) => {
   if ([Infinity, -Infinity, NaN, undefined].includes(val)) return `${val}`
   // https://v8.dev/features/subsume-json#security, e.g. {'\u2028':0} on Node.js 8


### PR DESCRIPTION
In pre-ES2019, those are not suitable for inserting in JS context.

This should affect Node.js 8 and below.

Refs: https://v8.dev/features/subsume-json