### PR TITLE
Stringify regex to new RegExp(...)

### DIFF
--- a/src/jaystring.js
+++ b/src/jaystring.js
@@ -28,10 +28,7 @@ function jaystring(item) {
     throw new Error('Can stringify only either normal or arrow functions')
   } else if (typeof item === 'object') {
     const proto = Object.getPrototypeOf(item)
-    if (item instanceof RegExp && proto === RegExp.prototype) {
-      // String(regex) is not ok on Node.js 10 and below: console.log(String(new RegExp('\n')))
-      return format('new RegExp(%j, %j)', item.source, item.flags)
-    }
+    if (item instanceof RegExp && proto === RegExp.prototype) return format('%r', item)
     throw new Error('Can not stringify an object with unexpected prototype')
   }
   throw new Error(`Cannot stringify ${item} - unknown type ${typeof item}`)

--- a/src/jaystring.js
+++ b/src/jaystring.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { jsval } = require('./safe-format')
+
 const isArrowFnWithParensRegex = /^\([^)]*\) *=>/
 const isArrowFnWithoutParensRegex = /^[^=]*=>/
 
@@ -26,7 +28,10 @@ function jaystring(item) {
     throw new Error('Can stringify only either normal or arrow functions')
   } else if (typeof item === 'object') {
     const proto = Object.getPrototypeOf(item)
-    if (item instanceof RegExp && proto === RegExp.prototype) return String(item)
+    if (item instanceof RegExp && proto === RegExp.prototype) {
+      // String(regex) is not ok on Node.js 10 and below: console.log(String(new RegExp('\n')))
+      return `new RegExp(${jsval(item.source)}, ${jsval(item.flags)})`
+    }
     throw new Error('Can not stringify an object with unexpected prototype')
   }
   throw new Error(`Cannot stringify ${item} - unknown type ${typeof item}`)

--- a/src/jaystring.js
+++ b/src/jaystring.js
@@ -30,7 +30,7 @@ function jaystring(item) {
     const proto = Object.getPrototypeOf(item)
     if (item instanceof RegExp && proto === RegExp.prototype) {
       // String(regex) is not ok on Node.js 10 and below: console.log(String(new RegExp('\n')))
-      return `new RegExp(${jsval(item.source)}, ${jsval(item.flags)})`
+      return format('new RegExp(%j, %j)', item.source, item.flags)
     }
     throw new Error('Can not stringify an object with unexpected prototype')
   }

--- a/src/jaystring.js
+++ b/src/jaystring.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { jsval } = require('./safe-format')
+const { format } = require('./safe-format')
 
 const isArrowFnWithParensRegex = /^\([^)]*\) *=>/
 const isArrowFnWithoutParensRegex = /^[^=]*=>/

--- a/src/safe-format.js
+++ b/src/safe-format.js
@@ -51,4 +51,4 @@ const safewrap = (fun) => (...args) => {
 const safeor = safewrap((...args) => args.join(' || ') || 'false')
 const safeand = safewrap((...args) => args.join(' && ') || 'true')
 
-module.exports = { format, safe, safeor, safeand }
+module.exports = { format, safe, safeor, safeand, jsval }

--- a/src/safe-format.js
+++ b/src/safe-format.js
@@ -51,4 +51,4 @@ const safewrap = (fun) => (...args) => {
 const safeor = safewrap((...args) => args.join(' || ') || 'false')
 const safeand = safewrap((...args) => args.join(' && ') || 'true')
 
-module.exports = { format, safe, safeor, safeand, jsval }
+module.exports = { format, safe, safeor, safeand }

--- a/src/safe-format.js
+++ b/src/safe-format.js
@@ -13,7 +13,7 @@ const jsval = (val) => {
 }
 
 const format = (fmt, ...args) => {
-  const res = fmt.replace(/%[%dscj]/g, (match) => {
+  const res = fmt.replace(/%[%drscj]/g, (match) => {
     if (match === '%%') return '%'
     if (args.length === 0) throw new Error('Unexpected arguments count')
     const val = args.shift()
@@ -21,6 +21,10 @@ const format = (fmt, ...args) => {
       case '%d':
         if (typeof val === 'number') return val
         throw new Error('Expected a number')
+      case '%r':
+        // String(regex) is not ok on Node.js 10 and below: console.log(String(new RegExp('\n')))
+        if (val instanceof RegExp) return format('new RegExp(%j, %j)', val.source, val.flags)
+        throw new Error('Expected a RegExp instance')
       case '%s':
         if (val instanceof SafeString) return val
         throw new Error('Expected a safe string')


### PR DESCRIPTION
After #46.

Otherwise wrong stringification can happen on Node.js 10 and below.

Demo (for old behavior): `console.log(String(new RegExp('\n')))`.