### PR TITLE
In json-only mode, don't check object keys for existance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -81,7 +81,7 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
     requireValidation = opts.mode === 'strong',
     requireStringValidation = opts.mode === 'strong',
     complexityChecks = opts.mode === 'strong',
-    isJSON = false, // assume input to be JSON, which e.g. makes undefined impossible
+    isJSON: optIsJSON = false, // assume input to be JSON, which e.g. makes undefined impossible
     jsonCheck = false, // disabled by default, it's assumed that data is from JSON.parse
     $schemaDefault = null,
     formats: optFormats = {},
@@ -104,6 +104,9 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
     throw new Error('Strong mode demands require(String)Validation and complexityChecks')
   if (mode === 'strong' && (weakFormats || allowUnusedKeywords))
     throw new Error('Strong mode forbids weakFormats and allowUnusedKeywords')
+  if (optIsJSON && jsonCheck)
+    throw new Error('Can not specify both isJSON and jsonCheck options, please choose one')
+  const isJSON = optIsJSON || jsonCheck
 
   if (!scope[scopeCache])
     scope[scopeCache] = { sym: new Map(), ref: new Map(), format: new Map(), pattern: new Map() }
@@ -339,7 +342,7 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
           cache.ref.set(sub, n)
           let fn = null // resolve cyclic dependencies
           scope[n] = (...args) => fn(...args)
-          const override = { includeErrors: false, jsonCheck: false }
+          const override = { includeErrors: false, jsonCheck: false, isJSON }
           fn = compile(sub, subRoot, { ...opts, ...override }, scope, path)
           scope[n] = fn
         }

--- a/src/index.js
+++ b/src/index.js
@@ -151,6 +151,7 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
   if (optIncludeErrors) fun.write('validate.errors = null')
   fun.write('let errors = 0')
 
+  let jsonCheckPerformed = false
   const getMeta = () => rootMeta.get(root) || {}
   const basePathStack = basePathRoot ? [basePathRoot] : []
   const visit = (allErrors, includeErrors, history, current, node, schemaPath) => {
@@ -208,6 +209,15 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
     const enforce = (ok, ...args) => ok || fail(...args)
     const enforceValidation = (msg) => enforce(!requireValidation, `[requireValidation] ${msg}`)
     const subPath = (...args) => [...schemaPath, ...args]
+
+    // JSON check is once only for the top-level object, before everything else
+    if (jsonCheck && !jsonCheckPerformed) {
+      /* c8 ignore next */
+      if (`${name}` !== 'data') throw new Error('Unreachable: invalid json check')
+      scope.deepEqual = functions.deepEqual
+      errorIf('!deepEqual(%s, JSON.parse(JSON.stringify(%s)))', [name, name], 'not JSON compatible')
+      jsonCheckPerformed = true
+    }
 
     if (typeof node === 'boolean') {
       if (node === true) {
@@ -310,12 +320,6 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
       fun.write('} else {')
     } else {
       fun.write('if (%s) {', present(current))
-    }
-
-    if (jsonCheck) {
-      // this check has to be done only after existance check and before all other checks
-      scope.deepEqual = functions.deepEqual
-      errorIf('!deepEqual(%s, JSON.parse(JSON.stringify(%s)))', [name, name], 'not JSON compatible')
     }
 
     if (node.$ref) {


### PR DESCRIPTION
Upd: depends on #59.

`Object.keys` are already present on the object itself, and can't be undefined because of JSON.

Also skip `hasOwn` check for `Object.keys` in non-JSON mode, leave only undefined check.
