### PR TITLE
Minor error handling fixes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -170,11 +170,11 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
     }
     const error = (msg, prop, value) => {
       if (includeErrors === true) {
-        const error = { field: prop || name, message: msg, schemaPath: toPointer(schemaPath) }
+        const errorObj = { field: prop || name, message: msg, schemaPath: toPointer(schemaPath) }
         if (verboseErrors) {
-          writeErrorObject(format('{ ...%j, value: %s }', error, value || name))
+          writeErrorObject(format('{ ...%j, value: %s }', errorObj, value || name))
         } else {
-          writeErrorObject(format('%j', error))
+          writeErrorObject(format('%j', errorObj))
         }
       }
       if (allErrors) {

--- a/src/index.js
+++ b/src/index.js
@@ -172,8 +172,7 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
       if (includeErrors === true) {
         const leanError = { field: prop || name, message: msg }
         if (verboseErrors) {
-          const type = node.type || 'any'
-          const fullError = { ...leanError, type, schemaPath: toPointer(schemaPath) }
+          const fullError = { ...leanError, schemaPath: toPointer(schemaPath) }
           writeErrorObject(format('{ ...%j, value: %s }', fullError, value || name))
         } else {
           writeErrorObject(format('%j', leanError))

--- a/src/index.js
+++ b/src/index.js
@@ -170,12 +170,11 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
     }
     const error = (msg, prop, value) => {
       if (includeErrors === true) {
-        const leanError = { field: prop || name, message: msg }
+        const error = { field: prop || name, message: msg, schemaPath: toPointer(schemaPath) }
         if (verboseErrors) {
-          const fullError = { ...leanError, schemaPath: toPointer(schemaPath) }
-          writeErrorObject(format('{ ...%j, value: %s }', fullError, value || name))
+          writeErrorObject(format('{ ...%j, value: %s }', error, value || name))
         } else {
-          writeErrorObject(format('%j', leanError))
+          writeErrorObject(format('%j', error))
         }
       }
       if (allErrors) {

--- a/src/pointer.js
+++ b/src/pointer.js
@@ -1,7 +1,7 @@
 'use strict'
 
 function toPointer(path) {
-  if (path.length === 0) return ''
+  if (path.length === 0) return '#'
   return `#/${path.map((part) => `${part}`.replace(/~/g, '~0').replace(/\//g, '~1')).join('/')}`
 }
 

--- a/test/misc.js
+++ b/test/misc.js
@@ -116,7 +116,6 @@ tape('additional props', function(t) {
     validate.errors[0].value === 'data.foo',
     'should output the property not allowed in verbose mode'
   )
-  t.strictEqual(validate.errors[0].type, 'object', 'error object should contain the type')
   t.end()
 })
 
@@ -418,7 +417,6 @@ tape('verbose mode', function(t) {
   t.ok(validate({ hello: 'string' }), 'should be valid')
   t.notOk(validate({ hello: 100 }), 'should not be valid')
   t.strictEqual(validate.errors[0].value, 100, 'error object should contain the invalid value')
-  t.strictEqual(validate.errors[0].type, 'string', 'error object should contain the type')
   t.end()
 })
 

--- a/test/schema-path.js
+++ b/test/schema-path.js
@@ -79,7 +79,7 @@ tape('schemaPath', function(t) {
     },
     additionalProperties: false,
   }
-  const validate = validator(schema, { includeErrors: true, verboseErrors: true })
+  const validate = validator(schema, { includeErrors: true })
 
   function notOkAt(data, path, message) {
     if (validate(data)) {

--- a/test/schema-path.js
+++ b/test/schema-path.js
@@ -96,8 +96,8 @@ tape('schemaPath', function(t) {
   }
 
   // Top level errors
-  notOkAt(null, '', 'should target parent of failed type error')
-  notOkAt(undefined, '', 'should target parent of failed type error')
+  notOkAt(null, '#', 'should target parent of failed type error')
+  notOkAt(undefined, '#', 'should target parent of failed type error')
   notOkWithTarget(
     { invalidAdditionalProp: '*whistles innocently*' },
     'top level',


### PR DESCRIPTION
1. Always return pointer as an URI fragment for consistency
2. Drop `.type` in verboseErrors
3. Always include schemaPath in errors
