### PR TITLE
fix: Properly encode `__proto__` in jsval()

### DIFF
--- a/doc/Secure-code-generation.md
+++ b/doc/Secure-code-generation.md
@@ -84,6 +84,24 @@ See https://v8.dev/features/subsume-json#security for more details.
 
 `format()` function handles that.
 
+### `__proto__` properties should be post-processed after `JSON.stringify`
+
+Even with the `\u2028` and `\u2029` difference resolved in newer ECMA Script specification versions
+and by post-processing, there is one more parsing difference between JSON and JS contexts which has
+to be accounted for before including JSON-stringified variables into JS context.
+
+`{"__proto__": ...` parses differently due JS having special-handling for it which JSON ingores:
+ * [ECMA 262, 24.5.1 `JSON.parse ( text [ , reviver ] )`](https://www.ecma-international.org/ecma-262/#sec-json.parse)
+ * [ECMA 262, B.3.1 `__proto__` Property Names in Object Initializers](https://www.ecma-international.org/ecma-262/#sec-__proto__-property-names-in-object-initializers)
+
+To account for that, all occurances of `{"__proto__":` should be replaced with `{["__proto__"]:`
+and all occurances of `,"__proto__":` — with `,["__proto__"]:`, after each `JSON.stringify` call.
+
+_The replacement above works given that `JSON.stringify` is used without the `space` formatting
+option. Full regex pattern for properties that need replacement is `/[^\\]"__proto__":/g`._
+
+`format()` function handles that.
+
 ### `RegExp` stringification should use `new RegExp()`
 
 Using `/regexp/` form, produced by converting a `RegExp` object to a string, is not safe.

--- a/doc/Secure-code-generation.md
+++ b/doc/Secure-code-generation.md
@@ -90,7 +90,7 @@ Even with the `\u2028` and `\u2029` difference resolved in newer ECMA Script spe
 and by post-processing, there is one more parsing difference between JSON and JS contexts which has
 to be accounted for before including JSON-stringified variables into JS context.
 
-`{"__proto__": ...` parses differently due JS having special-handling for it which JSON ingores:
+`{"__proto__": ...` parses differently due to JS having special-handling for it which JSON ignores:
  * [ECMA 262, 24.5.1 `JSON.parse ( text [ , reviver ] )`](https://www.ecma-international.org/ecma-262/#sec-json.parse)
  * [ECMA 262, B.3.1 `__proto__` Property Names in Object Initializers](https://www.ecma-international.org/ecma-262/#sec-__proto__-property-names-in-object-initializers)
 

--- a/test/regressions/proto-jsval.js
+++ b/test/regressions/proto-jsval.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const tape = require('tape')
+const { validator } = require('../../')
+
+tape('single', (t) => {
+  const validate = validator(JSON.parse('{"const": {"__proto__": []}}'))
+
+  t.notOk(validate({}), 'Empty object does not match')
+  t.notOk(validate([]), 'Empty array does not match')
+  t.notOk(validate({ __proto__: [] }), 'Object with overriden prototype does not match')
+  t.ok(validate({ ['__proto__']: [] }), 'Object with __proto__ property matches')
+  t.ok(validate(JSON.parse('{"__proto__": []}')), 'Equivalent JSON matches')
+  t.end()
+})
+
+tape('multiple', (t) => {
+  const validate = validator(JSON.parse('{"const": [{"__proto__": []}, {"__proto__": []}]}'))
+
+  const ok = { ['__proto__']: [] }
+  const fail = { __proto__: [] }
+
+  t.notOk(validate([]), 'Empty array does not match')
+  t.notOk(validate({ fail, ok }), 'First mismatch of two fails')
+  t.notOk(validate({ ok, fail }), 'Second mismatch of two fails')
+  t.ok(validate([ok, ok]), 'Objects with __proto__ properties match')
+  t.ok(validate(JSON.parse('[{"__proto__": []}, {"__proto__": []}]')), 'Equivalent JSON matches')
+  t.end()
+})


### PR DESCRIPTION
Refs: https://www.ecma-international.org/ecma-262/#sec-json.parse
Refs: https://www.ecma-international.org/ecma-262/#sec-__proto__-property-names-in-object-initializers

Tests and documentation with the explanation included.

While I can't directly see how those can harm outside of `useDefaults` and bugs in whatever code consumed those defaults, it still breaks expectations around `jsval()`.