### PR TITLE
Drop draft3-specific 'any' type

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -360,7 +360,7 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
     /* Preparation and methods, post-$ref validation will begin at the end of the function */
 
     const typeArray =
-      node.type === undefined ? null : (Array.isArray(node.type) ? node.type : [node.type])
+      node.type === undefined ? null : Array.isArray(node.type) ? node.type : [node.type]
     for (const t of typeArray || [])
       enforce(typeof t === 'string' && types.has(t), 'Unknown type:', t)
     if (typeArray === null) enforceValidation('type is required') // typeArray === null means no type validation

--- a/src/index.js
+++ b/src/index.js
@@ -360,7 +360,7 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
     /* Preparation and methods, post-$ref validation will begin at the end of the function */
 
     const typeArray =
-      node.type !== undefined ? (Array.isArray(node.type) ? node.type : [node.type]) : null
+      node.type === undefined ? null : (Array.isArray(node.type) ? node.type : [node.type])
     for (const t of typeArray || [])
       enforce(typeof t === 'string' && types.has(t), 'Unknown type:', t)
     if (typeArray === null) enforceValidation('type is required') // typeArray === null means no type validation

--- a/test/complexity.js
+++ b/test/complexity.js
@@ -35,7 +35,7 @@ const complex = [
   { format: 'complex' },
   { pattern: '^(a[a-z]+)*$' },
   { uniqueItems: true },
-  { uniqueItems: true, items: { type: 'any' } },
+  { uniqueItems: true, items: {} },
   { uniqueItems: true, items: { type: 'object' } },
   { uniqueItems: true, items: { type: ['string', 'number', 'array'] } },
   { uniqueItems: true, items: [{ type: 'string' }] },

--- a/test/json-schema.js
+++ b/test/json-schema.js
@@ -42,10 +42,8 @@ const unsupported = new Set([
   //  draft3 is deprecated and not fully supported
   'draft3/extends.json',
   'draft3/disallow.json',
+  'draft3/type.json', // we don't want draft3-specific type logic
   'draft3/ref.json/remote ref, containing refs itself',
-  'draft3/type.json/types can include schemas',
-  'draft3/type.json/when types includes a schema it should fully validate the schema',
-  'draft3/type.json/types from separate schemas are merged',
   'draft3/optional/ecmascript-regex.json/ECMA 262 regex dialect recognition', // broken assumption in test
 
   //  draft2019-09 is not supported yet


### PR DESCRIPTION
No reason to use it, it is just confusing.
ajv does not support it, for example.

Simplifies some logic before fixing #63 