### PR TITLE
fix: use correct error path in 'contains'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -578,7 +578,7 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
           errorIf('%s < %d', [passes, node.minContains], { path: ['minContains'] })
           consume('minContains', 'natural')
         } else {
-          errorIf('%s < 1', [passes], 'array does not contain a match', ['contains'])
+          errorIf('%s < 1', [passes], { path: ['contains'] })
         }
 
         if (Number.isFinite(node.maxContains)) {


### PR DESCRIPTION
Overlooked in 498f55f54756d061ab2ca6da06c475e71cbf623a

Refs: https://github.com/ExodusMovement/schemasafe/pull/73
Refs: https://github.com/ExodusMovement/schemasafe/commit/498f55f54756d061ab2ca6da06c475e71cbf623a#diff-1fdf421c05c1140f6d71444ea2b27638L575