### PR TITLE
Make regex complexity checks more paranoid

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -399,12 +399,12 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
       return (e) => format('(%s === %j)', variableName, e)
     }
 
-    const enforceRegex = (pattern, target = node) => {
-      enforce(typeof pattern === 'string', 'Invalid pattern:', pattern)
+    const enforceRegex = (source, target = node) => {
+      enforce(typeof source === 'string', 'Invalid pattern:', source)
       if (requireValidation || requireStringValidation)
-        enforce(/^\^.*\$$/.test(pattern), 'Should start with ^ and end with $:', pattern)
-      if (complexityChecks && (pattern.match(/[{+*]/g) || []).length > 1)
-        enforce(target.maxLength !== undefined, 'maxLength should be specified for:', pattern)
+        enforce(/^\^.*\$$/.test(source), 'Should start with ^ and end with $:', source)
+      if (complexityChecks && ((source.match(/[{+*]/g) || []).length > 1 || /\)[{+*]/.test(source)))
+        enforce(target.maxLength !== undefined, 'maxLength should be specified for:', source)
     }
 
     // Can not be used before undefined check above! The one performed by present()

--- a/test/complexity.js
+++ b/test/complexity.js
@@ -34,6 +34,8 @@ const simple = [
 const complex = [
   { format: 'complex' },
   { pattern: '^(a[a-z]+)*$' },
+  { pattern: '^(a|aa)*$' },
+  { pattern: '^(aa?)*$' },
   { uniqueItems: true },
   { uniqueItems: true, items: {} },
   { uniqueItems: true, items: { type: 'object' } },


### PR DESCRIPTION
E.g. `/^(a|aa)*$/` and `/^(aa?)*$/` also cause ReDoS, so warn users about them in strong mode.

Tests included.