### PR TITLE
Make allErrors not a DoS vector

### DIFF
--- a/doc/Error-handling.md
+++ b/doc/Error-handling.md
@@ -35,6 +35,10 @@ The options relevant to error reporting are:
 
   * `allErrors` — list all encountered errors, not just the first one. Requires `includeErrors`.
 
+    To ensure that this is not a [DoS vector](./Complexity-checks.md), `pattern`, `format`,
+    `propertyPatterns` and `uniqueItems` checks will be still skipped if the same exact data
+    property already failed length restrictions.
+
   * `verboseErrors` — include more information in each error object. Requires `includeErrors`.
 
 All of those are opt-ins (i.e. `false` by default).

--- a/doc/Error-handling.md
+++ b/doc/Error-handling.md
@@ -35,9 +35,11 @@ The options relevant to error reporting are:
 
   * `allErrors` — list all encountered errors, not just the first one. Requires `includeErrors`.
 
-    To ensure that this is not a [DoS vector](./Complexity-checks.md), `pattern`, `format`,
-    `propertyPatterns` and `uniqueItems` checks will be still skipped if the same exact data
-    property already failed length restrictions.
+    To ensure that this is not a [DoS vector](./Complexity-checks.md), `pattern`, `format` and
+    `uniqueItems` checks will be still skipped if the same exact data property already failed
+    other restrictions (and already caused an error which will be included), and `propertyPatterns`
+    will be skipped if the parent data object (containing the property) failed other restrictions.\
+    That does not affect the result of validation, just the list of reported errors in those cases.
 
   * `verboseErrors` — include more information in each error object. Requires `includeErrors`.
 

--- a/test/regressions/allErrors-dos.js
+++ b/test/regressions/allErrors-dos.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const tape = require('tape')
+const { validator } = require('../../')
+
+tape('allErrors do not cause a DoS (with length restrictions)', (t) => {
+  const validate = validator(
+    {
+      type: 'object',
+      properties: {
+        a: { uniqueItems: true, maxItems: 10 },
+        b: { pattern: '^(aa?)*$', maxLength: 10 },
+        c: { const: 'valid' },
+      },
+      propertyNames: {
+        maxLength: 10,
+      },
+      patternProperties: {
+        '^(d|dd)*$': { type: 'string' },
+      },
+    },
+    { complexityChecks: true, includeErrors: true, allErrors: true }
+  )
+  const t0 = process.hrtime()
+  t.notOk(
+    validate({
+      a: Array(1e5)
+        .fill()
+        .map((_, i) => [i]),
+      b: `${'a'.repeat(1e5)}b`,
+      c: 'nope',
+      [`${'d'.repeat(1e5)}a`]: ['not a string'],
+    }),
+    'validation fails'
+  )
+  const [seconds] = process.hrtime(t0)
+  t.strictEqual(seconds, 0, 'validation is fast')
+  t.ok(validate.errors && validate.errors.length >= 4, 'separate errors for each rule or property')
+  t.end()
+})

--- a/test/regressions/allErrors-dos.js
+++ b/test/regressions/allErrors-dos.js
@@ -11,6 +11,8 @@ tape('allErrors do not cause a DoS (with length restrictions)', (t) => {
         a: { uniqueItems: true, maxItems: 10 },
         b: { pattern: '^(aa?)*$', maxLength: 10 },
         c: { const: 'valid' },
+        e: { pattern: '^(aa?)*$', maxLength: 10 },
+        f: { uniqueItems: true, maxItems: 10 },
       },
       propertyNames: {
         maxLength: 10,
@@ -30,11 +32,13 @@ tape('allErrors do not cause a DoS (with length restrictions)', (t) => {
       b: `${'a'.repeat(1e5)}b`,
       c: 'nope',
       [`${'d'.repeat(1e5)}a`]: ['not a string'],
+      e: 'aab',
+      f: [1, 1],
     }),
     'validation fails'
   )
   const [seconds] = process.hrtime(t0)
   t.strictEqual(seconds, 0, 'validation is fast')
-  t.ok(validate.errors && validate.errors.length >= 4, 'separate errors for each rule or property')
+  t.ok(validate.errors && validate.errors.length >= 6, 'separate errors for each rule or property')
   t.end()
 })


### PR DESCRIPTION
This skips complex checks if corresponding length restrictions have already failed.

E.g., now included tests do not case a DoS even when `allErrors` is set to true.

Ensuring that schema limits that still requires `complexityChecks` (on by default in `strong` mode).

Best reviewed with hidden whitespace changes, as this involved indentation changes due to a wrapping block.