### PR TITLE
Cleaner error message on undefined nodes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -269,7 +269,7 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
       return
     }
 
-    enforce(Object.getPrototypeOf(node) === Object.prototype, 'Schema is not an object')
+    enforce(node && Object.getPrototypeOf(node) === Object.prototype, 'Schema is not an object')
     for (const key of Object.keys(node))
       enforce(KNOWN_KEYWORDS.includes(key) || allowUnusedKeywords, 'Keyword not supported:', key)
 

--- a/test/regressions/compile-errors.js
+++ b/test/regressions/compile-errors.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const tape = require('tape')
+const { inspect } = require('util')
+const { validator } = require('../../')
+
+tape('Schema should be an object', (t) => {
+  for (const arg of [undefined, null, [], 0, 42, Infinity, /regexp/, 'string', Buffer.alloc(0)])
+    t.throws(() => validator(arg), /Schema is not an object/, `Throws on ${inspect(arg)}`)
+
+  for (const arg of [false, true, {}])
+    t.doesNotThrow(() => validator(arg), `Does not throw on ${inspect(arg)}`)
+
+  t.end()
+})


### PR DESCRIPTION
Before, it threw with `Cannot convert undefined or null to object` in some cases.

Now, all non-object invalid schemas produce `Schema is not an object` error.

Tests included.

No actual behavior change except for the clarified error message.