### PR TITLE
pointer: fix objpath2path conversion on 'id' properties

### DIFF
--- a/src/pointer.js
+++ b/src/pointer.js
@@ -48,7 +48,7 @@ function joinPath(baseFull, sub) {
 
 function objpath2path(objpath) {
   const ids = objpath.map((obj) => (obj && (obj.$id || obj.id)) || '')
-  return ids.filter((id) => id).reduce(joinPath, '')
+  return ids.filter((id) => id && typeof id === 'string').reduce(joinPath, '')
 }
 
 function resolveReference(root, additionalSchemas, ref, base = '') {


### PR DESCRIPTION
Similar to line 70 of the same file: https://github.com/ExodusMovement/schemasafe/pull/91/files#diff-8aba63a34e9613927ab97bbc39471c29R70

Tests will come separately.