### PR TITLE
Store schemas in a Map, accept object/map/array

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 const { format, safe, safeand, safeor } = require('./safe-format')
 const genfun = require('./generate-function')
-const { resolveReference, joinPath } = require('./pointer')
+const { resolveReference, joinPath, buildSchemas } = require('./pointer')
 const formats = require('./formats')
 const functions = require('./scope-functions')
 const KNOWN_KEYWORDS = require('./known-keywords')
@@ -94,7 +94,7 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
     formats: optFormats = {},
     weakFormats = opts.mode !== 'strong',
     extraFormats = false,
-    schemas = {},
+    schemas: optSchemas = {},
     ...unknown
   } = opts
   const fmts = {
@@ -114,6 +114,7 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
   if (optIsJSON && jsonCheck)
     throw new Error('Can not specify both isJSON and jsonCheck options, please choose one')
   const isJSON = optIsJSON || jsonCheck
+  const schemas = buildSchemas(optSchemas)
 
   if (!scope[scopeCache])
     scope[scopeCache] = { sym: new Map(), ref: new Map(), format: new Map(), pattern: new Map() }
@@ -359,7 +360,7 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
     }
 
     if (node.$ref) {
-      const resolved = resolveReference(root, schemas || {}, node.$ref, basePath())
+      const resolved = resolveReference(root, schemas, node.$ref, basePath())
       const [sub, subRoot, path] = resolved[0] || []
       if (sub || sub === false) {
         let n = cache.ref.get(sub)

--- a/src/pointer.js
+++ b/src/pointer.js
@@ -53,7 +53,7 @@ function objpath2path(objpath) {
 
 function resolveReference(root, additionalSchemas, ref, base = '') {
   const ptr = joinPath(base, ref)
-  const schemas = new Map(Object.entries(additionalSchemas))
+  const schemas = new Map(additionalSchemas)
   const self = (base || '').split('#')[0]
   if (self) schemas.set(self, root)
 
@@ -98,4 +98,28 @@ function resolveReference(root, additionalSchemas, ref, base = '') {
   return results
 }
 
-module.exports = { get, joinPath, resolveReference }
+const buildSchemas = (input) => {
+  if (input) {
+    switch (Object.getPrototypeOf(input)) {
+      case Object.prototype:
+        return new Map(Object.entries(input))
+      case Map.prototype:
+        return new Map(input)
+      case Array.prototype: {
+        const schemas = new Map()
+        for (const schema of input) {
+          const id = schema.$id || schema.id
+          if (!id || typeof id !== 'string') throw new Error("Schema without $id in 'schemas'")
+          const cleanId = id.replace(/#$/, '') // # is allowed only as the last symbol here
+          if (!cleanId || cleanId.includes('#')) throw new Error("Unexpected $id in 'schemas'")
+          if (schemas.has(cleanId)) throw new Error("Duplicate schema $id in 'schemas'")
+          schemas.set(cleanId, schema)
+        }
+        return schemas
+      }
+    }
+  }
+  throw new Error("Unexpected value of 'schemas' option")
+}
+
+module.exports = { get, joinPath, resolveReference, buildSchemas }

--- a/test/json-schema.js
+++ b/test/json-schema.js
@@ -60,20 +60,35 @@ const unsupported = new Set([
   'draft2019-09/optional/format/duration.json',
 ])
 
-const schemas = {
+const schemas = [
   // standard
-  'https://json-schema.org/draft/2019-09/schema': require('./schemas/json-schema-draft-2019-09.json'),
-  'http://json-schema.org/draft-07/schema': require('./schemas/json-schema-draft-07.json'),
-  'http://json-schema.org/draft-06/schema': require('./schemas/json-schema-draft-06.json'),
-  'http://json-schema.org/draft-04/schema': require('./schemas/json-schema-draft-04.json'),
-  'http://json-schema.org/draft-03/schema': require('./schemas/json-schema-draft-03.json'),
+  require('./schemas/json-schema-draft-2019-09.json'),
+  require('./schemas/json-schema-draft-07.json'),
+  require('./schemas/json-schema-draft-06.json'),
+  require('./schemas/json-schema-draft-04.json'),
+  require('./schemas/json-schema-draft-03.json'),
   // remote
-  'http://localhost:1234/integer.json': require('./JSON-Schema-Test-Suite/remotes/integer.json'),
-  'http://localhost:1234/subSchemas.json': require('./JSON-Schema-Test-Suite/remotes/subSchemas.json'),
-  'http://localhost:1234/folder/folderInteger.json': require('./JSON-Schema-Test-Suite/remotes/folder/folderInteger.json'),
-  'http://localhost:1234/name.json': require('./JSON-Schema-Test-Suite/remotes/name.json'),
-  'http://localhost:1234/name-defs.json': require('./JSON-Schema-Test-Suite/remotes/name-defs.json'),
-}
+  {
+    $id: 'http://localhost:1234/integer.json',
+    ...require('./JSON-Schema-Test-Suite/remotes/integer.json'),
+  },
+  {
+    $id: 'http://localhost:1234/subSchemas.json',
+    ...require('./JSON-Schema-Test-Suite/remotes/subSchemas.json'),
+  },
+  {
+    $id: 'http://localhost:1234/folder/folderInteger.json',
+    ...require('./JSON-Schema-Test-Suite/remotes/folder/folderInteger.json'),
+  },
+  {
+    $id: 'http://localhost:1234/name.json',
+    ...require('./JSON-Schema-Test-Suite/remotes/name.json'),
+  },
+  {
+    $id: 'http://localhost:1234/name-defs.json',
+    ...require('./JSON-Schema-Test-Suite/remotes/name-defs.json'),
+  },
+]
 
 function processTestDir(schemaDir, main, subdir = '') {
   const dir = path.join(__dirname, schemaDir, main, subdir)


### PR DESCRIPTION
This allows specifying a list of schemas as an Array instead of an object, which should make consuming easier.

Schema identifiers are taken from `$id` properties in that case.