### PR TITLE
tests: introduce ajv test suite

### DIFF
--- a/test/ajv-spec/extras.part/const.json
+++ b/test/ajv-spec/extras.part/const.json
@@ -1,0 +1,65 @@
+[
+  {
+    "description": "const keyword requires the value to be equal to some constant",
+    "schema": { "const": 2 },
+    "tests": [
+      {
+        "description": "same value is valid",
+        "data": 2,
+        "valid": true
+      },
+      {
+        "description": "another value is invalid",
+        "data": 5,
+        "valid": false
+      },
+      {
+        "description": "another type is invalid",
+        "data": "a",
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "const keyword requires the value to be equal to some object",
+    "schema": { "const": { "foo": "bar", "baz": "bax" } },
+    "tests": [
+      {
+        "description": "same object is valid",
+        "data": { "foo": "bar", "baz": "bax" },
+        "valid": true
+      },
+      {
+        "description": "same object with different property order is valid",
+        "data": { "baz": "bax", "foo": "bar" },
+        "valid": true
+      },
+      {
+        "description": "another object is invalid",
+        "data": { "foo": "bar" },
+        "valid": false
+      },
+      {
+        "description": "another type is invalid",
+        "data": [ 1, 2 ],
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "const keyword with null",
+    "schema": { "const": null },
+    "tests": [
+      {
+        "description": "null is valid",
+        "data": null,
+        "valid": true
+      },
+      {
+        "description": "not null is invalid",
+        "data": 0,
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/extras.part/contains.json
+++ b/test/ajv-spec/extras.part/contains.json
@@ -1,0 +1,53 @@
+[
+  {
+    "description": "contains keyword requires the item matching schema to be present",
+    "schema": {
+        "contains": { "minimum": 5 }
+    },
+    "tests": [
+      {
+        "description": "array with item matching schema (5) is valid",
+        "data": [3, 4, 5],
+        "valid": true
+      },
+      {
+        "description": "array with item matching schema (6) is valid",
+        "data": [3, 4, 6],
+        "valid": true
+      },
+      {
+        "description": "array without item matching schema is invalid",
+        "data": [1, 2, 3, 4],
+        "valid": false
+      },
+      {
+        "description": "empty array is invalid",
+        "data": [],
+        "valid": false
+      },
+      {
+        "description": "not array is valid",
+        "data": {},
+        "valid": true
+      }
+    ]
+  },
+  {
+    "description": "contains keyword with const keyword requires a specific item to be present",
+    "schema": {
+        "contains": { "const": 5 }
+    },
+    "tests": [
+      {
+        "description": "array with item 5 is valid",
+        "data": [3, 4, 5],
+        "valid": true
+      },
+      {
+        "description": "array without item 5 is invalid",
+        "data": [1, 2, 3, 4],
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/extras.part/propertyNames.json
+++ b/test/ajv-spec/extras.part/propertyNames.json
@@ -1,0 +1,32 @@
+[
+  {
+    "description": "propertyNames validation",
+    "schema": {
+      "type": "object",
+      "propertyNames": { "format": "email" }
+    },
+    "tests": [
+      {
+        "description": "all property names valid",
+        "data": {
+          "foo@example.com": {},
+          "bar.baz@email.example.com": {}
+        },
+        "valid": true
+      },
+      {
+        "description": "some property names invalid",
+        "data": {
+          "foo": {},
+          "bar.baz@email.example.com": {}
+        },
+        "valid": false
+      },
+      {
+        "description": "object without properties is valid",
+        "data": {},
+        "valid": true
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/remotes/bar.json
+++ b/test/ajv-spec/remotes/bar.json
@@ -1,0 +1,4 @@
+{
+  "$id": "http://localhost:1234/bar.json",
+  "type": "string"
+}

--- a/test/ajv-spec/remotes/buu.json
+++ b/test/ajv-spec/remotes/buu.json
@@ -1,0 +1,11 @@
+{
+  "$id": "http://localhost:1234/buu.json",
+  "definitions": {
+    "buu": {
+      "type": "object",
+      "properties": {
+        "bar": { "$ref": "bar.json" }
+      }
+    }
+  }
+}

--- a/test/ajv-spec/remotes/first.json
+++ b/test/ajv-spec/remotes/first.json
@@ -1,0 +1,4 @@
+{
+    "$id": "http://localhost:1234/first.json",
+    "type": "string"
+}

--- a/test/ajv-spec/remotes/foo.json
+++ b/test/ajv-spec/remotes/foo.json
@@ -1,0 +1,7 @@
+{
+  "$id": "http://localhost:1234/foo.json",
+  "type": "object",
+  "properties": {
+    "bar": { "$ref": "bar.json" }
+  }
+}

--- a/test/ajv-spec/remotes/hyper-schema.json
+++ b/test/ajv-spec/remotes/hyper-schema.json
@@ -1,0 +1,69 @@
+{
+    "$schema": "http://json-schema.org/draft-07/hyper-schema#",
+    "$id": "http://json-schema.org/draft-07/hyper-schema#",
+    "title": "JSON Hyper-Schema",
+    "definitions": {
+        "schemaArray": {
+            "allOf": [
+                { "$ref": "http://json-schema.org/draft-07/schema#/definitions/schemaArray" },
+                {
+                    "items": { "$ref": "#" }
+                }
+            ]
+        }
+    },
+    "allOf": [ { "$ref": "http://json-schema.org/draft-07/schema#" } ],
+    "properties": {
+        "additionalItems": { "$ref": "#" },
+        "additionalProperties": { "$ref": "#"},
+        "dependencies": {
+            "additionalProperties": {
+                "anyOf": [
+                    { "$ref": "#" },
+                    { "type": "array" }
+                ]
+            }
+        },
+        "items": {
+            "anyOf": [
+                { "$ref": "#" },
+                { "$ref": "#/definitions/schemaArray" }
+            ]
+        },
+        "definitions": {
+            "additionalProperties": { "$ref": "#" }
+        },
+        "patternProperties": {
+            "additionalProperties": { "$ref": "#" }
+        },
+        "properties": {
+            "additionalProperties": { "$ref": "#" }
+        },
+        "if": {"$ref": "#"},
+        "then": {"$ref": "#"},
+        "else": {"$ref": "#"},
+        "allOf": { "$ref": "#/definitions/schemaArray" },
+        "anyOf": { "$ref": "#/definitions/schemaArray" },
+        "oneOf": { "$ref": "#/definitions/schemaArray" },
+        "not": { "$ref": "#" },
+        "contains": { "$ref": "#" },
+        "propertyNames": { "$ref": "#" },
+
+        "base": {
+            "type": "string",
+            "format": "uri-template"
+        },
+        "links": {
+            "type": "array",
+            "items": {
+                "$ref": "http://json-schema.org/draft-07/hyper-schema#/links"
+            }
+        }
+    },
+    "links": [
+        {
+            "rel": "self",
+            "href": "{+%24id}"
+        }
+    ]
+}

--- a/test/ajv-spec/remotes/name.json
+++ b/test/ajv-spec/remotes/name.json
@@ -1,0 +1,11 @@
+{
+  "definitions": {
+    "orNull": {
+      "anyOf": [
+        { "type": "null" },
+        { "$ref": "#" }
+      ]
+    }
+  },
+  "type": "string"
+}

--- a/test/ajv-spec/remotes/node.json
+++ b/test/ajv-spec/remotes/node.json
@@ -1,0 +1,10 @@
+{
+  "$id": "http://localhost:1234/node.json",
+  "description": "node",
+  "type": "object",
+  "properties": {
+    "value": { "type": "number" },
+    "subtree": { "$ref": "tree.json" }
+  },
+  "required": ["value"]
+}

--- a/test/ajv-spec/remotes/scope_change.json
+++ b/test/ajv-spec/remotes/scope_change.json
@@ -1,0 +1,21 @@
+{
+  "$id": "http://localhost:1234/scope_change.json",
+  "definitions": {
+    "foo": {
+      "$id": "http://localhost:1234/scope_foo.json",
+      "definitions": {
+        "bar": {
+          "type": "string"
+        }
+      }
+    },
+    "baz": {
+      "$id": "folder/",
+      "type": "array",
+      "items": { "$ref": "folderInteger.json" },
+      "bar": {
+        "items": { "$ref": "folderInteger.json" }
+      }
+    }
+  }
+}

--- a/test/ajv-spec/remotes/second.json
+++ b/test/ajv-spec/remotes/second.json
@@ -1,0 +1,7 @@
+{
+    "$id": "http://localhost:1234/second.json",
+    "type": "object",
+    "properties": {
+        "first": { "$ref": "first.json" }
+    }
+}

--- a/test/ajv-spec/remotes/tree.json
+++ b/test/ajv-spec/remotes/tree.json
@@ -1,0 +1,13 @@
+{
+  "$id": "http://localhost:1234/tree.json",
+  "description": "tree of nodes",
+  "type": "object",
+  "properties": {
+    "meta": { "type": "string" },
+    "nodes": {
+      "type": "array",
+      "items": { "$ref": "node.json"}
+    }
+  },
+  "required": ["meta", "nodes"]
+}

--- a/test/ajv-spec/tests/issues/1061_alternative_time_offsets.json
+++ b/test/ajv-spec/tests/issues/1061_alternative_time_offsets.json
@@ -1,0 +1,74 @@
+[
+  {
+    "description": "Support for alternative ISO-8601 timezone offset formats (#1061)",
+    "schema": {"format": "date-time"},
+    "tests": [
+      {
+        "description": "valid positiive two digit",
+        "data": "2016-01-31T02:31:17+01",
+        "valid": true
+      },
+      {
+        "description": "valid negative two digit",
+        "data": "2016-01-31T02:31:17-01",
+        "valid": true
+      },
+      {
+        "description": "valid positiive four digit no colon",
+        "data": "2016-01-31T02:31:17+0130",
+        "valid": true
+      },
+      {
+        "description": "valid negative four digit no colon",
+        "data": "2016-01-31T02:31:17-0130",
+        "valid": true
+      },
+      {
+        "description": "invalid positiive three digit no colon",
+        "data": "2016-01-31T02:31:17+013",
+        "valid": false
+      },
+      {
+        "description": "invalid negative three digit no colon",
+        "data": "2016-01-31T02:31:17-013",
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "Support for alternative ISO-8601 timezone offset formats (#1061)",
+    "schema": {"format": "time"},
+    "tests": [
+      {
+        "description": "valid positiive two digit",
+        "data": "02:31:17+01",
+        "valid": true
+      },
+      {
+        "description": "valid negative two digit",
+        "data": "02:31:17-01",
+        "valid": true
+      },
+      {
+        "description": "valid positiive four digit no colon",
+        "data": "02:31:17+0130",
+        "valid": true
+      },
+      {
+        "description": "valid negative four digit no colon",
+        "data": "02:31:17-0130",
+        "valid": true
+      },
+      {
+        "description": "invalid positiive three digit no colon",
+        "data": "02:31:17+013",
+        "valid": false
+      },
+      {
+        "description": "invalid negative three digit no colon",
+        "data": "02:31:17-013",
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/issues/12_restoring_root_after_resolve.json
+++ b/test/ajv-spec/tests/issues/12_restoring_root_after_resolve.json
@@ -1,0 +1,62 @@
+[
+  {
+    "description": "restoring root after ref resolution (#12)",
+    "schema": {
+      "definitions": {
+        "int": { "$ref": "http://localhost:1234/integer.json" },
+        "str": { "type": "string" }
+      },
+      "anyOf": [
+        { "$ref": "#/definitions/int" },
+        { "$ref": "#/definitions/str" }
+      ]
+    },
+    "tests": [
+      {
+        "description": "valid string",
+        "data": "foo",
+        "valid": true
+      },
+      {
+        "description": "valid number",
+        "data": 1,
+        "valid": true
+      },
+      {
+        "description": "invalid object",
+        "data": {},
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "all refs are in the same place",
+    "schema": {
+      "definitions": {
+        "int": { "type": "integer" },
+        "str": { "type": "string" }
+      },
+      "anyOf": [
+        { "$ref": "#/definitions/int" },
+        { "$ref": "#/definitions/str" }
+      ]
+    },
+    "tests": [
+      {
+        "description": "valid string",
+        "data": "foo",
+        "valid": true
+      },
+      {
+        "description": "valid number",
+        "data": 1,
+        "valid": true
+      },
+      {
+        "description": "invalid object",
+        "data": {},
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/issues/13_root_ref_in_ref_in_remote_ref.json
+++ b/test/ajv-spec/tests/issues/13_root_ref_in_ref_in_remote_ref.json
@@ -1,0 +1,37 @@
+[
+  {
+    "description": "root ref in remote ref (#13)",
+    "schema": {
+      "$id": "http://localhost:1234/issue13",
+      "type": "object",
+      "properties": {
+        "name": { "$ref": "name.json#/definitions/orNull" }
+      }
+    },
+    "tests": [
+      {
+        "description": "string is valid",
+        "data": {
+          "name": "foo"
+        },
+        "valid": true
+      },
+      {
+        "description": "null is valid",
+        "data": {
+          "name": null
+        },
+        "valid": true
+      },
+      {
+        "description": "object is invalid",
+        "data": {
+          "name": {
+            "name": null
+          }
+        },
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/issues/14_ref_in_remote_ref_with_id.json
+++ b/test/ajv-spec/tests/issues/14_ref_in_remote_ref_with_id.json
@@ -1,0 +1,58 @@
+[
+  {
+    "description": "ref in remote ref with ids",
+    "schema": {
+      "$id": "http://localhost:1234/issue14a.json",
+      "type": "array",
+      "items": { "$ref": "foo.json" }
+    },
+    "tests": [
+      {
+        "description": "string is valid",
+        "data": [
+          {
+            "bar": "any string"
+          }
+        ],
+        "valid": true
+      },
+      {
+        "description": "not string is invalid",
+        "data": [
+          {
+            "bar": 1
+          }
+        ],
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "remote ref in definitions in remote ref with ids (#14)",
+    "schema": {
+      "$id": "http://localhost:1234/issue14b.json",
+      "type": "array",
+      "items": { "$ref": "buu.json#/definitions/buu" }
+    },
+    "tests": [
+      {
+        "description": "string is valid",
+        "data": [
+          {
+            "bar": "any string"
+          }
+        ],
+        "valid": true
+      },
+      {
+        "description": "not string is invalid",
+        "data": [
+          {
+            "bar": 1
+          }
+        ],
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/issues/170_ref_and_id_in_sibling.json
+++ b/test/ajv-spec/tests/issues/170_ref_and_id_in_sibling.json
@@ -1,0 +1,301 @@
+[
+  {
+    "description": "sibling property has id (#170)",
+    "schemas": [
+      {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "http://example.com/base_object_1",
+        "type": "object",
+        "properties": {
+          "title": {
+            "$id": "http://example.com/title",
+            "type": "string"
+          },
+          "file": { "$ref": "#/definitions/file-entry" }
+        },
+        "definitions": {
+          "file-entry": { "type": "string" }
+        }
+      },
+      {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "http://example.com/base_object_2",
+        "type": "object",
+        "properties": {
+          "title": {
+            "$id": "http://example.com/title",
+            "type": "string"
+          },
+          "file": { "$ref": "#/definitions/file-entry" }
+        },
+        "definitions": {
+          "file-entry": { "type": "string" }
+        }
+      }
+    ],
+    "tests": [
+      {
+        "description": "valid object",
+        "data": {
+          "title": "foo",
+          "file": "bar"
+        },
+        "valid": true
+      },
+      {
+        "description": "invalid object",
+        "data": {
+          "title": "foo",
+          "file": 2
+        },
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "sibling item has id",
+    "schemas": [
+      {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "http://example.com/base_array_1",
+        "type": "array",
+        "items": [
+          {
+            "$id": "http://example.com/0",
+            "type": "string"
+          },
+          { "$ref": "#/definitions/file-entry" }
+        ],
+        "definitions": {
+          "file-entry": { "type": "string" }
+        }
+      },
+      {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "http://example.com/base_array_2",
+        "type": "array",
+        "items": [
+          {
+            "$id": "http://example.com/0",
+            "type": "string"
+          },
+          { "$ref": "#/definitions/file-entry" }
+        ],
+        "definitions": {
+          "file-entry": { "type": "string" }
+        }
+      }
+    ],
+    "tests": [
+      {
+        "description": "valid array",
+        "data": [ "foo", "bar" ],
+        "valid": true
+      },
+      {
+        "description": "invalid array",
+        "data": [ "foo", 2 ],
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "sibling schema in anyOf has id",
+    "schemas": [
+      {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "http://example.com/base_anyof_1",
+        "anyOf": [
+          {
+            "$id": "http://example.com/0",
+            "type": "number"
+          },
+          { "$ref": "#/definitions/def" }
+        ],
+        "definitions": {
+          "def": { "type": "string" }
+        }
+      },
+      {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "http://example.com/base_anyof_2",
+        "anyOf": [
+          {
+            "$id": "http://example.com/0",
+            "type": "number"
+          },
+          { "$ref": "#/definitions/def" }
+        ],
+        "definitions": {
+          "def": { "type": "string" }
+        }
+      }
+    ],
+    "tests": [
+      {
+        "description": "valid string",
+        "data": "foo",
+        "valid": true
+      },
+      {
+        "description": "valid number",
+        "data": 1,
+        "valid": true
+      },
+      {
+        "description": "invalid object",
+        "data": {},
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "sibling schema in oneOf has id",
+    "schemas": [
+      {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "http://example.com/base_oneof_1",
+        "oneOf": [
+          {
+            "$id": "http://example.com/0",
+            "type": "number"
+          },
+          { "$ref": "#/definitions/def" }
+        ],
+        "definitions": {
+          "def": { "type": "string" }
+        }
+      },
+      {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "http://example.com/base_oneof_2",
+        "oneOf": [
+          {
+            "$id": "http://example.com/0",
+            "type": "number"
+          },
+          { "$ref": "#/definitions/def" }
+        ],
+        "definitions": {
+          "def": { "type": "string" }
+        }
+      }
+    ],
+    "tests": [
+      {
+        "description": "valid string",
+        "data": "foo",
+        "valid": true
+      },
+      {
+        "description": "valid number",
+        "data": 1,
+        "valid": true
+      },
+      {
+        "description": "invalid object",
+        "data": {},
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "sibling schema in allOf has id",
+    "schemas": [
+      {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "http://example.com/base_allof_1",
+        "allOf": [
+          {
+            "$id": "http://example.com/0",
+            "type": "string",
+            "maxLength": 3
+          },
+          { "$ref": "#/definitions/def" }
+        ],
+        "definitions": {
+          "def": { "type": "string" }
+        }
+      },
+      {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "http://example.com/base_allof_2",
+        "allOf": [
+          {
+            "$id": "http://example.com/0",
+            "type": "string",
+            "maxLength": 3
+          },
+          { "$ref": "#/definitions/def" }
+        ],
+        "definitions": {
+          "def": { "type": "string" }
+        }
+      }
+    ],
+    "tests": [
+      {
+        "description": "valid string",
+        "data": "foo",
+        "valid": true
+      },
+      {
+        "description": "invalid string",
+        "data": "quux",
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "sibling schema in dependencies has id",
+    "schemas": [
+      {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "http://example.com/base_dependencies_1",
+        "type": "object",
+        "dependencies": {
+          "foo": {
+            "$id": "http://example.com/foo",
+            "required": [ "bar" ]
+          },
+          "bar": { "$ref": "#/definitions/def" }
+        },
+        "definitions": {
+          "def": { "required": [ "baz" ] }
+        }
+      },
+      {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "http://example.com/base_dependencies_2",
+        "type": "object",
+        "dependencies": {
+          "foo": {
+            "$id": "http://example.com/foo",
+            "required": [ "bar" ]
+          },
+          "bar": { "$ref": "#/definitions/def" }
+        },
+        "definitions": {
+          "def": { "required": [ "baz" ] }
+        }
+      }
+    ],
+    "tests": [
+      {
+        "description": "valid object",
+        "data": { "foo": 1, "bar": 2, "baz": 3 },
+        "valid": true
+      },
+      {
+        "description": "invalid object 2",
+        "data": { "foo": 1 },
+        "valid": false
+      },
+      {
+        "description": "invalid object 2",
+        "data": { "foo": 1, "bar": 2 },
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/issues/17_escaping_pattern_property.json
+++ b/test/ajv-spec/tests/issues/17_escaping_pattern_property.json
@@ -1,0 +1,22 @@
+[
+  {
+    "description": "escaping pattern property (#17)",
+    "schema": {
+      "type" : "object",
+      "patternProperties": {
+        "^.+$" : {
+          "type" : "object",
+          "required" : ["unit"]
+        }
+      },
+      "additionalProperties" : false
+    },
+    "tests": [
+      {
+        "description": "empty object",
+        "data": {},
+        "valid": true
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/issues/19_required_many_properties.json
+++ b/test/ajv-spec/tests/issues/19_required_many_properties.json
@@ -1,0 +1,96 @@
+[
+  {
+    "description": "Required for many properties in inner level (#19)",
+    "schema": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "p1",
+          "p2",
+          "p3",
+          "p4",
+          "p5",
+          "p6",
+          "p7",
+          "p8",
+          "p9",
+          "p10",
+          "p11",
+          "p12",
+          "p13",
+          "p14",
+          "p15",
+          "p16",
+          "p17",
+          "p18",
+          "p19",
+          "p20",
+          "p21",
+          "p22"
+        ]
+      }
+    },
+    "tests": [
+      {
+        "description": "valid",
+        "data": [
+          {
+            "p1": "test",
+            "p2": "test",
+            "p3": "test",
+            "p4": "test",
+            "p5": "test",
+            "p6": "test",
+            "p7": "test",
+            "p8": "test",
+            "p9": "test",
+            "p10": "test",
+            "p11": "test",
+            "p12": "test",
+            "p13": "test",
+            "p14": "test",
+            "p15": "test",
+            "p16": "test",
+            "p17": "test",
+            "p18": "test",
+            "p19": "test",
+            "p20": "test",
+            "p21": "test",
+            "p22": "test"
+          }
+        ],
+        "valid": true
+      },
+      {
+        "description": "invalid",
+        "data": [
+          {
+            "p2": "test",
+            "p3": "test",
+            "p4": "test",
+            "p5": "test",
+            "p6": "test",
+            "p7": "test",
+            "p8": "test",
+            "p9": "test",
+            "p10": "test",
+            "p11": "test",
+            "p12": "test",
+            "p13": "test",
+            "p14": "test",
+            "p15": "test",
+            "p16": "test",
+            "p17": "test",
+            "p18": "test",
+            "p19": "test",
+            "p20": "test",
+            "p21": "test",
+            "p22": "test"
+          }
+        ],
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/issues/1_ids_in_refs.json
+++ b/test/ajv-spec/tests/issues/1_ids_in_refs.json
@@ -1,0 +1,73 @@
+[
+  {
+    "description": "IDs in refs without root id (#1)",
+    "schemas": [
+      {
+        "definitions": {
+          "int": {
+            "$id": "#int",
+            "type": "integer"
+          }
+        },
+        "$ref": "#int"
+      },
+      {
+        "definitions": {
+          "int": {
+            "$id": "#int",
+            "type": "integer"
+          }
+        },
+        "$ref": "#int"
+      }
+    ],
+    "tests": [
+      { "description": "valid", "data": 1, "valid": true },
+      { "description": "invalid", "data": "foo", "valid": false }
+    ]
+  },
+  {
+    "description": "IDs in refs with root id",
+    "schemas": [
+      {
+        "$id": "http://example.com/int_1.json",
+        "definitions": {
+          "int": {
+            "$id": "#int",
+            "type": "integer"
+          }
+        },
+        "$ref": "#int"
+      },
+      {
+        "$id": "http://example.com/int_2.json",
+        "definitions": {
+          "int": {
+            "$id": "#int",
+            "type": "integer"
+          }
+        },
+        "$ref": "#int"
+      }
+    ],
+    "tests": [
+      { "description": "valid", "data": 1, "valid": true },
+      { "description": "invalid", "data": "foo", "valid": false }
+    ]
+  },
+  {
+    "description": "Definitions instead of IDs",
+    "schema": {
+      "definitions": {
+        "int": {
+          "type": "integer"
+        }
+      },
+      "$ref": "#/definitions/int"
+    },
+    "tests": [
+      { "description": "valid", "data": 1, "valid": true },
+      { "description": "invalid", "data": "foo", "valid": false }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/issues/20_failing_to_parse_schema.json
+++ b/test/ajv-spec/tests/issues/20_failing_to_parse_schema.json
@@ -1,0 +1,94 @@
+[
+  {
+    "description": "Failing to parse schema with required property that is not an identifier (#20)",
+    "schema": {
+        "type": "object",
+        "required": [ "a-b", "a'", "a\"" ]
+    },
+    "tests": [
+      {
+        "description": "valid",
+        "data": {
+          "a-b": "test",
+          "a'": "test",
+          "a\"": "test"
+        },
+        "valid": true
+      },
+      {
+        "description": "invalid",
+        "data": {},
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "Failing to parse schema with required property that is not an identifier for many properties (#20)",
+    "schema": {
+        "type": "object",
+        "required": [
+          "a-1",
+          "a-2",
+          "a-3",
+          "a-4",
+          "a-5",
+          "a-6",
+          "a-7",
+          "a-8",
+          "a-9",
+          "a-10",
+          "a-11",
+          "a-12",
+          "a-13",
+          "a-14",
+          "a-15",
+          "a-16",
+          "a-17",
+          "a-18",
+          "a-19",
+          "a-20",
+          "a-21",
+          "a-22",
+          "'",
+          "\""
+        ]
+    },
+    "tests": [
+      {
+        "description": "valid",
+        "data": {
+          "a-1": "test",
+          "a-2": "test",
+          "a-3": "test",
+          "a-4": "test",
+          "a-5": "test",
+          "a-6": "test",
+          "a-7": "test",
+          "a-8": "test",
+          "a-9": "test",
+          "a-10": "test",
+          "a-11": "test",
+          "a-12": "test",
+          "a-13": "test",
+          "a-14": "test",
+          "a-15": "test",
+          "a-16": "test",
+          "a-17": "test",
+          "a-18": "test",
+          "a-19": "test",
+          "a-20": "test",
+          "a-21": "test",
+          "a-22": "test",
+          "'": "test",
+          "\"": "test"
+        },
+        "valid": true
+      },
+      {
+        "description": "invalid",
+        "data": {},
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/issues/226_json_with_control_chars.json
+++ b/test/ajv-spec/tests/issues/226_json_with_control_chars.json
@@ -1,0 +1,146 @@
+[
+  {
+    "description": "JSON with control characters - 'properties' (#226)",
+    "schema": {
+      "properties": {
+        "foo\nbar": { "type": "number" },
+        "foo\"bar": { "type": "number" },
+        "foo\\bar": { "type": "number" },
+        "foo\rbar": { "type": "number" },
+        "foo\tbar": { "type": "number" },
+        "foo\fbar": { "type": "number" }
+      }
+    },
+    "tests": [
+      {
+        "description": "object with all numbers is valid",
+        "data": {
+          "foo\nbar": 1,
+          "foo\"bar": 1,
+          "foo\\bar": 1,
+          "foo\rbar": 1,
+          "foo\tbar": 1,
+          "foo\fbar": 1
+        },
+        "valid": true
+      },
+      {
+        "description": "object with strings is invalid",
+        "data": {
+          "foo\nbar": "1",
+          "foo\"bar": "1",
+          "foo\\bar": "1",
+          "foo\rbar": "1",
+          "foo\tbar": "1",
+          "foo\fbar": "1"
+        },
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "JSON with control characters - 'required' (#226)",
+    "schema": {
+      "required": [
+        "foo\nbar",
+        "foo\"bar",
+        "foo\\bar",
+        "foo\rbar",
+        "foo\tbar",
+        "foo\fbar"
+      ]
+    },
+    "tests": [
+      {
+        "description": "object with all properties present is valid",
+        "data": {
+          "foo\nbar": 1,
+          "foo\"bar": 1,
+          "foo\\bar": 1,
+          "foo\rbar": 1,
+          "foo\tbar": 1,
+          "foo\fbar": 1
+        },
+        "valid": true
+      },
+      {
+        "description": "object with some properties missing is invalid",
+        "data": {
+          "foo\nbar": "1",
+          "foo\"bar": "1"
+        },
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "JSON with control characters - 'enum'",
+    "schema": {
+      "enum": [ "foo\nbar", "foo\rbar" ]
+    },
+    "tests": [
+      {
+        "description": "member 1 is valid",
+        "data": "foo\nbar",
+        "valid": true
+      },
+      {
+        "description": "member 2 is valid",
+        "data": "foo\rbar",
+        "valid": true
+      },
+      {
+        "description": "another string is invalid",
+        "data": "abc",
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "JSON with control characters - 'dependencies'",
+    "schema": {
+      "dependencies": {
+        "foo\nbar": [ "foo\rbar" ],
+        "foo\tbar": {
+          "minProperties": 4
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "valid object 1",
+        "data": {
+          "foo\nbar": 1,
+          "foo\rbar": 2
+        },
+        "valid": true
+      },
+      {
+        "description": "valid object 2",
+        "data": {
+          "foo\tbar": 1,
+          "a": 2,
+          "b": 3,
+          "c": 4
+        },
+        "valid": true
+      },
+      {
+        "description": "invalid object 1",
+        "data": {
+          "foo\nbar": 1,
+          "foo": 2
+        },
+        "valid": false
+      },
+      {
+        "description": "invalid object 2",
+        "data": {
+          "foo\tbar": 1,
+          "a": 2
+        },
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/issues/27_1_recursive_raml_schema.json
+++ b/test/ajv-spec/tests/issues/27_1_recursive_raml_schema.json
@@ -1,0 +1,623 @@
+[
+  {
+    "description": "JSON Schema for a standard RAML object (#27)",
+    "schema": {
+      "title": "A JSON Schema for a standard RAML object",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [
+        "title"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "The title property is a short plain text description of the RESTful API. The title property's value SHOULD be suitable for use as a title for the contained user documentation."
+        },
+        "version": {
+          "type": "string",
+          "description": "If the RAML API definition is targeted to a specific API version, the API definition MUST contain a version property."
+        },
+        "baseUri": {
+          "type": "string",
+          "format": "uri",
+          "description": "A RESTful API's resources are defined relative to the API's base URI. The use of the baseUri field is OPTIONAL to allow describing APIs that have not yet been implemented."
+        },
+        "baseUriParameters": {
+          "$ref": "#/definitions/namedParameters"
+        },
+        "mediaType": {
+          "$ref": "#/definitions/mediaType"
+        },
+        "protocols": {
+          "$ref": "#/definitions/protocols"
+        },
+        "securitySchemes": {
+          "$ref": "#/definitions/securitySchemes"
+        },
+        "securedBy": {
+          "$ref": "#/definitions/securedBy"
+        },
+        "documentation": {
+          "$ref": "#/definitions/documentation"
+        },
+        "resources": {
+          "$ref": "#/definitions/rootResource"
+        },
+        "traits": {
+          "$ref": "#/definitions/traits"
+        },
+        "resourceTypes": {
+          "$ref": "#/definitions/resourceTypes"
+        }
+      },
+      "definitions": {
+        "namedParameters": {
+          "patternProperties": {
+            "^[\\w-]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/namedParameter"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/namedParameter"
+                  }
+                }
+              ]
+            }
+          },
+          "description": "This RAML Specification describes collections of named parameters for the following properties: URI parameters, query string parameters, form parameters, request bodies (depending on the media type), and request and response headers. Read more: https://github.com/raml-org/raml-spec/blob/master/raml-0.8.md#named-parameters"
+        },
+        "namedParameter": {
+          "type": "object",
+          "properties": {
+            "displayName": {
+              "type": "string",
+              "description": "The displayName attribute specifies the parameter's display name. It is a friendly name used only for display or documentation purposes. If displayName is not specified, it defaults to the property's key (the name of the property itself)."
+            },
+            "description": {
+              "type": "string",
+              "description": "The description attribute describes the intended use or meaning of the parameter. This value MAY be formatted using Markdown."
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "string",
+                "number",
+                "integer",
+                "date",
+                "boolean",
+                "file"
+              ],
+              "default": "string",
+              "description": "The type attribute specifies the primitive type of the parameter's resolved value. If the type is not specified, it defaults to string. API clients MUST return/throw an error if the parameter's resolved value does not match the specified type."
+            },
+            "enum": {
+              "$ref": "#/definitions/enum",
+              "description": "The enum attribute provides an enumeration of the parameter's valid values. This MUST be an array. If the enum attribute is defined, API clients and servers MUST verify that a parameter's value matches a value in the enum array. If there is no matching value, the clients and servers MUST treat this as an error."
+            },
+            "pattern": {
+              "type": "string",
+              "format": "regex",
+              "description": "The pattern attribute is a regular expression that a parameter of type string MUST match. Regular expressions MUST follow the regular expression specification from ECMA 262/Perl 5."
+            },
+            "minLength": {
+              "$ref": "#/definitions/minIntegerDefault0",
+              "description": "The minLength attribute specifies the parameter value's minimum number of characters."
+            },
+            "maxLength": {
+              "$ref": "#/definitions/minInteger",
+              "description": "The maxLength attribute specifies the parameter value's maximum number of characters."
+            },
+            "minimum": {
+              "type": "number",
+              "description": "The minimum attribute specifies the parameter's minimum value."
+            },
+            "maximum": {
+              "type": "number",
+              "description": "The maximum attribute specifies the parameter's maximum value."
+            },
+            "example": {
+              "$ref": "#/definitions/primitiveType",
+              "description": "The example attribute shows an example value for the property. This can be used, e.g., by documentation generators to generate sample values for the property."
+            },
+            "repeat": {
+              "$ref": "#/definitions/booleanDefaultFalse",
+              "description": "The repeat attribute specifies that the parameter can be repeated. If the parameter can be used multiple times, the repeat parameter value MUST be set to true. Otherwise, the default value is false and the parameter may not be repeated."
+            },
+            "required": {
+              "$ref": "#/definitions/booleanDefaultFalse",
+              "description": "The required attribute specifies whether the parameter and its value MUST be present in the API definition. It must be either 'true' if the value MUST be present or false otherwise. arameters are optional unless the required attribute is included and its value set to true. For a URI parameter, the required attribute MAY be omitted, but its default value is true."
+            },
+            "default": {
+              "$ref": "#/definitions/primitiveType",
+              "default": "The default attribute specifies the default value to use for the property if the property is omitted or its value is not specified. This SHOULD NOT be interpreted as a requirement for the client to send the default attribute's value if there is no other value to send. Instead, the default attribute's value is the value the server uses if the client does not send a value."
+            }
+          },
+          "additionalProperties": false
+        },
+        "mediaType": {
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9!#$%^&*_\\-+{}|'.`~]+/[a-zA-Z0-9!#$%^&*_\\-+{}|'.`~]+$",
+          "description": "The media types returned by API responses, and expected from API requests that accept a body, MAY be defaulted by specifying the mediaType property."
+        },
+        "protocols": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": ["HTTP", "HTTPS"]
+          },
+          "uniqueItems": true,
+          "description": "A RESTful API can be reached via HTTP, HTTPS, or both. The protocols property MAY be used to specify the protocols that an API supports. If the protocols property is not specified, the protocol specified at the baseUri property is used."
+        },
+        "securitySchemes": {
+          "type": "object",
+          "patternProperties": {
+            "^[\\w-]+$": {
+              "$ref": "#/definitions/securityScheme"
+            }
+          },
+          "additionalProperties": false,
+          "description": "The securitySchemes property MUST be used to specify an API's security mechanisms, including the required settings and the authentication methods that the API supports. one authentication method is allowed if the API supports them."
+        },
+        "securityScheme": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "The type attribute MAY be used to convey information about authentication flows and mechanisms to processing applications such as Documentation Generators and Client generators."
+            },
+            "description": {
+              "type": "string",
+              "description": "The description attribute MAY be used to describe a securitySchemes property."
+            },
+            "describedBy": {
+              "$ref": "#/definitions/describedBy"
+            },
+            "settings": {
+              "type": "object",
+              "description": "The settings attribute MAY be used to provide security schema-specific information. Depending on the value of the type parameter, its attributes can vary."
+            }
+          },
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "type"
+              ],
+              "properties": {
+                "type": {
+                  "enum": ["OAuth 1.0"]
+                },
+                "settings": {
+                  "type": "object",
+                  "required": [
+                    "requestTokenUri",
+                    "authorizationUri",
+                    "tokenCredentialsUri"
+                  ],
+                  "properties": {
+                    "requestTokenUri": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "authorizationUri": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "tokenCredentialsUri": {
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "type"
+              ],
+              "properties": {
+                "type": {
+                  "enum": ["OAuth 2.0"]
+                },
+                "settings": {
+                  "type": "object",
+                  "required": [
+                    "authorizationUri",
+                    "accessTokenUri",
+                    "authorizationGrants"
+                  ],
+                  "properties": {
+                    "authorizationUri": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "accessTokenUri": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "authorizationGrants": {
+                      "type": "array",
+                      "items": {
+                        "enum": ["code", "token", "owner", "credentials"]
+                      }
+                    },
+                    "scopes": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "type"
+              ],
+              "properties": {
+                "type": {
+                  "oneOf": [
+                    {
+                      "enum": [
+                        "Basic Authentication",
+                        "Digest Authentication"
+                      ]
+                    },
+                    {
+                      "type": "string",
+                      "pattern": "^x-"
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "additionalProperties": false
+        },
+        "traits": {
+          "type": "object",
+          "patternProperties": {
+            "^[\\w-]+$": {
+              "$ref": "#/definitions/trait"
+            }
+          },
+          "additionalProperties": false
+        },
+        "describedBy": {
+          "type": "object",
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "queryParameters": {
+              "$ref": "#/definitions/namedParameters"
+            },
+            "headers": {
+              "$ref": "#/definitions/namedParameters"
+            },
+            "responses": {
+              "$ref": "#/definitions/responses"
+            },
+            "body": {
+              "$ref": "#/definitions/body"
+            }
+          },
+          "additionalProperties": false,
+          "description": "The describedBy attribute MAY be used to apply a trait-like structure to a security scheme mechanism so as to extend the mechanism, such as specifying response codes, HTTP headers or custom documentation."
+        },
+        "trait": {
+          "type": "object",
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "queryParameters": {
+              "$ref": "#/definitions/namedParameters"
+            },
+            "headers": {
+              "$ref": "#/definitions/namedParameters"
+            },
+            "responses": {
+              "$ref": "#/definitions/responses"
+            },
+            "body": {
+              "$ref": "#/definitions/body"
+            },
+            "securedBy": {
+              "$ref": "#/definitions/securedBy"
+            }
+          },
+          "additionalProperties": false,
+          "description": "A trait is a partial method definition that, like a method, can provide method-level properties such as description, headers, query string parameters, and responses. Methods that use one or more traits inherit those traits' properties."
+        },
+        "resourceTypes": {
+          "type": "object",
+          "patternProperties": {
+            "^[\\w-]+$": {
+              "$ref": "#/definitions/resourceType"
+            }
+          }
+        },
+        "resourceType": {
+          "type": "object",
+          "properties": {
+            "is": {
+              "$ref": "#/definitions/is"
+            },
+            "type": {
+              "$ref": "#/definitions/reference"
+            }
+          },
+          "patternProperties": {
+            "^(?:head|get|post|put|patch|delete|options|trace|connect)\\??$": {
+              "$ref": "#/definitions/method"
+            }
+          },
+          "additionalProperties": false,
+          "description": "A resource type is a partial resource definition that, like a resource, can specify a description and methods and their properties. Resources that use a resource type inherit its properties, such as its methods."
+        },
+        "body": {
+          "type": "object",
+          "properties": {
+            "schema": {
+              "type": "string"
+            },
+            "formParameters": {
+              "$ref": "#/definitions/namedParameters"
+            },
+            "application/x-www-form-urlencoded": {
+              "$ref": "#/definitions/formBody"
+            },
+            "multipart/form-data": {
+              "$ref": "#/definitions/formBody"
+            },
+            "application/json": {
+              "$ref": "#/definitions/schemaBody"
+            },
+            "text/xml": {
+              "$ref": "#/definitions/schemaBody"
+            }
+          },
+          "patternProperties": {
+            "^[a-zA-Z0-9!#$%^&*_\\-+{}|'.`~]+/[a-zA-Z0-9!#$%^&*_\\-+{}|'.`~]+$": {
+              "$ref": "#/definitions/standardResponseBody"
+            }
+          },
+          "additionalProperties": false
+        },
+        "formBody": {
+          "$ref": "#/definitions/responseBody",
+          "properties": {
+            "formParameters": {
+              "$ref": "#/definitions/namedParameters"
+            }
+          },
+          "additionalProperties": false,
+          "description": "Web forms REQUIRE special encoding and custom declaration."
+        },
+        "schemaBody": {
+          "$ref": "#/definitions/responseBody",
+          "properties": {
+            "schema": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "description": "The structure of a request or response body MAY be further specified by the schema property under the appropriate media type."
+        },
+        "standardResponseBody": {
+          "$ref": "#/definitions/responseBody",
+          "additionalProperties": false
+        },
+        "responseBody": {
+          "type": ["null", "object"],
+          "properties": {
+            "example": {
+              "type": "string"
+            }
+          }
+        },
+        "responses": {
+          "type": "object",
+          "patternProperties": {
+            "^\\d{3}$": {
+              "$ref": "#/definitions/response"
+            }
+          },
+          "additionalProperties": false
+        },
+        "response": {
+          "type": "object",
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "headers": {
+              "$ref": "#/definitions/namedParameters",
+              "description": "An API's methods may support custom header values in responses. The custom, non-standard HTTP headers MUST be specified by the headers property."
+            },
+            "body": {
+              "$ref": "#/definitions/body"
+            }
+          },
+          "additionalProperties": false
+        },
+        "securedBy": {
+          "$ref": "#/definitions/enum",
+          "items": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/definitions/reference"
+              }
+            ]
+          },
+          "description": "A securityScheme may also be applied to a resource by using the securedBy key, which is equivalent to applying the securityScheme to all methods that may be declared, explicitly or implicitly, by defining the resourceTypes or traits property for that resource."
+        },
+        "reference": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[\\w-]+$"
+            },
+            {
+              "type": "object",
+              "minProperties": 1,
+              "maxProperties": 1,
+              "patternProperties": {
+                "^[\\w-]+$": {
+                  "type": "object"
+                }
+              }
+            }
+          ]
+        },
+        "documentation": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "content": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "description": "The API definition can include a variety of documents that serve as a user guides and reference documentation for the API. Such documents can clarify how the API works or provide business context."
+        },
+        "rootResource": {
+          "type": "object",
+          "patternProperties": {
+            "^/": {
+              "$ref": "#/definitions/resource"
+            }
+          },
+          "additionalProperties": false
+        },
+        "resource": {
+          "type": "object",
+          "properties": {
+            "displayName": {
+              "type": "string",
+              "description": "The displayName attribute provides a friendly name to the resource and can be used by documentation generation tools. The displayName key is OPTIONAL. If the displayName attribute is not defined for a resource, documentation tools SHOULD refer to the resource by its property key (i.e. its relative URI, e.g., \"/jobs\"), which acts as the resource's name."
+            },
+            "description": {
+              "type": "string",
+              "description": "Each resource, whether top-level or nested, MAY contain a description property that briefly describes the resource. It is RECOMMENDED that all the API definition's resources includes the description property."
+            },
+            "uriParameters": {
+              "$ref": "#/definitions/namedParameters"
+            },
+            "is": {
+              "$ref": "#/definitions/is"
+            },
+            "type": {
+              "$ref": "#/definitions/reference"
+            }
+          },
+          "patternProperties": {
+            "^(?:head|get|post|put|patch|delete|options|trace|connect)$": {
+              "$ref": "#/definitions/method"
+            },
+            "^/": {
+              "$ref": "#/definitions/resource"
+            }
+          },
+          "additionalProperties": false
+        },
+        "method": {
+          "type": "object",
+          "properties": {
+            "description": {
+              "type": "string",
+              "description": "Each declared method MAY contain a description attribute that briefly describes what the method does to the resource. It is RECOMMENDED that all API definition methods include the description property."
+            },
+            "queryParameters": {
+              "$ref": "#/definitions/namedParameters",
+              "description": "An API's resources MAY be filtered (to return a subset of results) or altered (such as transforming a response body from JSON to XML format) by the use of query strings. If the resource or its method supports a query string, the query string MUST be defined by the queryParameters property."
+            },
+            "headers": {
+              "$ref": "#/definitions/namedParameters",
+              "description": "An API's methods MAY support or require non-standard HTTP headers. In the API definition, specify the non-standard HTTP headers by using the headers property."
+            },
+            "protocols": {
+              "$ref": "#/definitions/protocols",
+              "description": "A method can override an API's protocols value for that single method by setting a different value for the fields."
+            },
+            "responses": {
+              "$ref": "#/definitions/responses",
+              "description": "Resource methods MAY have one or more responses. Responses MAY be described using the description property, and MAY include example attributes or schema properties."
+            },
+            "body": {
+              "$ref": "#/definitions/body",
+              "description": "Some method verbs expect the resource to be sent as a request body. For example, to create a resource, the request must include the details of the resource to create. Resources CAN have alternate representations. For example, an API might support both JSON and XML representations."
+            },
+            "securedBy": {
+              "$ref": "#/definitions/securedBy"
+            },
+            "is": {
+              "$ref": "#/definitions/is"
+            }
+          },
+          "additionalProperties": false
+        },
+        "is": {
+          "$ref": "#/definitions/enum",
+          "items": {
+            "$ref": "#/definitions/reference"
+          }
+        },
+        "enum": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "minInteger": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "minIntegerDefault0": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/minInteger"
+            },
+            {
+              "default": 0
+            }
+          ]
+        },
+        "booleanDefaultFalse": {
+          "type": "boolean",
+          "default": false
+        },
+        "date": {
+          "type": "string",
+          "pattern": "^(?:Sun|Mon|Tue|Wed|Thu|Fri|Sat), \\d{2} (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \\d{4} \\d{2}:\\d{2}:\\d{2} GMT$"
+        },
+        "primitiveType": {
+          "type": ["boolean", "integer", "number", "string"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "tests": [
+      {
+        "description": "empty object is invalid",
+        "data": {},
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/issues/27_recursive_reference.json
+++ b/test/ajv-spec/tests/issues/27_recursive_reference.json
@@ -1,0 +1,116 @@
+[
+  {
+    "description": "Recursive reference (#27)",
+    "schemas": [
+      {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "testrec_1",
+        "type": "object",
+        "properties": {
+          "layout": {
+            "$id": "layout",
+            "type": "object",
+            "properties": {
+              "layout": { "type": "string" },
+              "panels": {
+                "type": "array",
+                "items": {
+                  "anyOf": [
+                    { "type": "string" },
+                    { "$ref": "layout" }
+                  ]
+                }
+              }
+            },
+            "required": [
+              "layout",
+              "panels"
+            ]
+          }
+        }
+      },
+      {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "testrec_2",
+        "type": "object",
+        "properties": {
+          "layout": {
+            "$id": "layout",
+            "type": "object",
+            "properties": {
+              "layout": { "type": "string" },
+              "panels": {
+                "type": "array",
+                "items": {
+                  "anyOf": [
+                    { "type": "string" },
+                    { "$ref": "layout" }
+                  ]
+                }
+              }
+            },
+            "required": [
+              "layout",
+              "panels"
+            ]
+          }
+        }
+      }
+    ],
+    "tests": [
+      {
+        "description": "empty object is valid",
+        "data": {},
+        "valid": true
+      },
+      {
+        "description": "valid object",
+        "data": {
+          "layout": {
+            "layout": "test1",
+            "panels": [
+              "panel1",
+              {
+                "layout": "test2",
+                "panels": [
+                  "panel2",
+                  {
+                    "layout": "test3",
+                    "panels": [
+                      "panel3"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "invalid object",
+        "data": {
+          "layout": {
+            "layout": "test1",
+            "panels": [
+              "panel1",
+              {
+                "layout": "test2",
+                "panels": [
+                  "panel2",
+                  {
+                    "layout": "test3",
+                    "panels": [
+                      3
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/issues/28_escaping_pattern_error.json
+++ b/test/ajv-spec/tests/issues/28_escaping_pattern_error.json
@@ -1,0 +1,21 @@
+[
+  {
+    "description": "escaping pattern error (#28)",
+    "schema": {
+      "type" : "object",
+      "properties": {
+        "mediaType": {
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9!#$%^&*_\\-+{}|'.`~]+/[a-zA-Z0-9!#$%^&*_\\-+{}|'.`~]+$"
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "empty object",
+        "data": {},
+        "valid": true
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/issues/2_root_ref_in_ref.json
+++ b/test/ajv-spec/tests/issues/2_root_ref_in_ref.json
@@ -1,0 +1,140 @@
+[
+  {
+    "description": "root ref in ref (#2)",
+    "schema": {
+      "definitions": {
+        "arr": {
+           "type": "array",
+           "items": { "$ref": "#" }
+        }
+      },
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "children": { "$ref": "#/definitions/arr" }
+      }
+    },
+    "tests": [
+      {
+        "description": "valid",
+        "data": {
+          "name": "foo",
+          "children": [
+            { "name": "bar" },
+            { "name": "baz" }
+          ]
+        },
+        "valid": true
+      },
+      {
+        "description": "child numbers are invalid",
+        "data": {
+          "name": "foo",
+          "children": [
+            { "name": 1 },
+            { "name": 2 }
+          ]
+        },
+        "valid": false
+      },
+      {
+        "description": "child arrays are invalid",
+        "data": {
+          "name": "foo",
+          "children": [
+            [ ],
+            [ ]
+          ]
+        },
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "root ref in ref with anyOf (#2)",
+    "schema": {
+      "definitions": {
+        "orNull": {
+          "anyOf": [
+            { "type": "null" },
+            { "$ref": "#" }
+          ]
+        }
+      },
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "parent": { "$ref": "#/definitions/orNull" }
+      }
+    },
+    "tests": [
+      {
+        "description": "null parent is valid",
+        "data": {
+          "name": "foo",
+          "parent": null
+        },
+        "valid": true
+      },
+      {
+        "skip": false,
+        "description": "object parent is valid",
+        "data": {
+          "name": "foo",
+          "parent": {
+            "name": "bar",
+            "parent": null
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "object parent is valid",
+        "data": {
+          "name": "foo",
+          "parent": {
+            "name": "bar",
+            "parent": {
+              "name": "baz",
+              "parent": null
+            }
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "string parent is invalid",
+        "data": {
+          "name": "foo",
+          "parent": "buu"
+        },
+        "valid": false
+      },
+      {
+        "description": "string subparent is invalid",
+        "data": {
+          "name": "foo",
+          "parent": {
+            "name": "bar",
+            "parent": "baz"
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "string sub-subparent is invalid",
+        "data": {
+          "name": "foo",
+          "parent": {
+            "name": "bar",
+            "parent": {
+              "name": "baz",
+              "parent": "quux"
+            }
+          }
+        },
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/issues/311_quotes_in_refs.json
+++ b/test/ajv-spec/tests/issues/311_quotes_in_refs.json
@@ -1,0 +1,39 @@
+[
+  {
+    "description": "quotes in refs (#311)",
+    "schema": {
+      "properties": {
+        "foo\"bar": { "$ref": "#/definitions/foo\"bar" }
+      },
+      "definitions": {
+        "foo\"bar": { "type": "number" }
+      }
+    },
+    "tests": [
+      {
+        "description": "object with all numbers is valid",
+        "data": {
+          "foo\"bar": 1,
+          "foo\\bar": 1,
+          "foo\nbar": 1,
+          "foo\rbar": 1,
+          "foo\tbar": 1,
+          "foo\fbar": 1
+        },
+        "valid": true
+      },
+      {
+        "description": "object with strings is invalid",
+        "data": {
+          "foo\"bar": "1",
+          "foo\\bar": "1",
+          "foo\nbar": "1",
+          "foo\rbar": "1",
+          "foo\tbar": "1",
+          "foo\fbar": "1"
+        },
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/issues/33_json_schema_latest.json
+++ b/test/ajv-spec/tests/issues/33_json_schema_latest.json
@@ -1,0 +1,21 @@
+[
+  {
+    "description": "use latest json schema as v4 (#33)",
+    "schema": {
+      "$schema": "http://json-schema.org/schema",
+      "type": "object",
+      "properties": {
+        "username": {
+          "type": "string"
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "empty object",
+        "data": {},
+        "valid": true
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/issues/413_dependencies_with_quote.json
+++ b/test/ajv-spec/tests/issues/413_dependencies_with_quote.json
@@ -1,0 +1,29 @@
+[
+  {
+    "description": "JSON with control characters - 'dependencies'",
+    "schema": {
+      "dependencies": {
+        "foo'bar": {
+          "not": { "required": ["bar"] }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "valid object",
+        "data": {
+          "foo'bar": 1
+        },
+        "valid": true
+      },
+      {
+        "description": "invalid object",
+        "data": {
+          "foo'bar": 1,
+          "bar": 2
+        },
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/issues/490_integer_validation.json
+++ b/test/ajv-spec/tests/issues/490_integer_validation.json
@@ -1,0 +1,31 @@
+[
+  {
+    "description": "integer validation (#490)",
+    "schema": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "tests": [
+      {
+        "description": "valid integer",
+        "data": 1,
+        "valid": true
+      },
+      {
+        "description": "invalid integer",
+        "data": -1,
+        "valid": false
+      },
+      {
+        "description": "non-integer number is invalid",
+        "data": 1.1,
+        "valid": false
+      },
+      {
+        "description": "string is invalid",
+        "data": "foo",
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/issues/502_contains_empty_array_with_ref_in_another_property.json
+++ b/test/ajv-spec/tests/issues/502_contains_empty_array_with_ref_in_another_property.json
@@ -1,0 +1,65 @@
+[
+  {
+    "description": "\"contains\" allows empty array when ref is used in sibling property (#502)",
+    "schema": {
+      "type": "object",
+      "properties": {
+        "str": { "$ref": "#/definitions/str" },
+        "arr": {
+          "type": "array",
+          "contains": { "type": "number" }
+        }
+      },
+      "definitions": {
+        "str": { "type": "string" }
+      }
+    },
+    "tests": [
+      {
+        "description": "valid object 1",
+        "data": {
+          "str": "a",
+          "arr": [1]
+        },
+        "valid": true
+      },
+      {
+        "description": "valid object 2",
+        "data": {
+          "arr": [1]
+        },
+        "valid": true
+      },
+      {
+        "description": "invalid object 1",
+        "data": {
+          "str": "a",
+          "arr": ["b"]
+        },
+        "valid": false
+      },
+      {
+        "description": "invalid object 2",
+        "data": {
+          "arr": ["b"]
+        },
+        "valid": false
+      },
+      {
+        "description": "invalid object 3",
+        "data": {
+          "arr": []
+        },
+        "valid": false
+      },
+      {
+        "description": "invalid object 4 (fails in #502)",
+        "data": {
+          "str": "a",
+          "arr": []
+        },
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/issues/5_adding_dependency_after.json
+++ b/test/ajv-spec/tests/issues/5_adding_dependency_after.json
@@ -1,0 +1,18 @@
+[
+  {
+    "description": "Adding dependency after dependent schema (#5)",
+    "schema": "http://localhost:1234/second.json",
+    "tests": [
+      {
+        "description": "valid object",
+        "data": { "first": "foo" },
+        "valid": true
+      },
+      {
+        "description": "valid object",
+        "data": { "first": 1 },
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/issues/5_recursive_references.json
+++ b/test/ajv-spec/tests/issues/5_recursive_references.json
@@ -1,0 +1,66 @@
+[
+  {
+    "description": "Recursive references between schemas (#5)",
+    "schema": "http://localhost:1234/tree.json",
+    "tests": [
+      {
+        "description": "valid tree",
+        "data": { 
+          "meta": "root",
+          "nodes": [
+            {
+              "value": 1,
+              "subtree": {
+                "meta": "child",
+                "nodes": [
+                  { "value": 1.1 },
+                  { "value": 1.2 }
+                ]
+              }
+            },
+            {
+              "value": 2,
+              "subtree": {
+                "meta": "child",
+                "nodes": [
+                  { "value": 2.1 },
+                  { "value": 2.2 }
+                ]
+              }
+            }
+          ]
+        },
+        "valid": true
+      },
+      {
+        "description": "invalid tree",
+        "data": { 
+          "meta": "root",
+          "nodes": [
+            {
+              "value": 1,
+              "subtree": {
+                "meta": "child",
+                "nodes": [
+                  { "value": "string is invalid" },
+                  { "value": 1.2 }
+                ]
+              }
+            },
+            {
+              "value": 2,
+              "subtree": {
+                "meta": "child",
+                "nodes": [
+                  { "value": 2.1 },
+                  { "value": 2.2 }
+                ]
+              }
+            }
+          ]
+        },
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/issues/62_resolution_scope_change.json
+++ b/test/ajv-spec/tests/issues/62_resolution_scope_change.json
@@ -1,0 +1,65 @@
+[
+  {
+    "description": "change resolution scope - change filename (#62)",
+    "schema": {
+      "type" : "object",
+      "properties": {
+        "title": { "$ref": "http://localhost:1234/scope_foo.json#/definitions/bar" }
+      }
+    },
+    "tests": [
+      {
+        "description": "string is valid",
+        "data": { "title": "baz" },
+        "valid": true
+      },
+      {
+        "description": "number is invalid",
+        "data": { "title": 1 },
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "resolution scope change - change folder (#62)",
+    "schema": {
+      "type" : "object",
+      "properties": {
+        "list": { "$ref": "http://localhost:1234/scope_change.json#/definitions/baz" }
+      }
+    },
+    "tests": [
+      {
+        "description": "number is valid",
+        "data": { "list": [1] },
+        "valid": true
+      },
+      {
+        "description": "string is invalid",
+        "data": { "list": ["a"] },
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "resolution scope change - change folder in subschema (#62)",
+    "schema": {
+      "type" : "object",
+      "properties": {
+        "list": { "$ref": "http://localhost:1234/scope_change.json#/definitions/baz/bar" }
+      }
+    },
+    "tests": [
+      {
+        "description": "number is valid",
+        "data": { "list": [1] },
+        "valid": true
+      },
+      {
+        "description": "string is invalid",
+        "data": { "list": ["a"] },
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/issues/63_id_property_not_in_schema.json
+++ b/test/ajv-spec/tests/issues/63_id_property_not_in_schema.json
@@ -1,0 +1,28 @@
+[
+  {
+    "description": "id property in referenced schema in object that is not a schema (#63)",
+    "schema": {
+      "type" : "object",
+      "properties": {
+        "title": { "$ref": "http://json-schema.org/draft-07/schema#/properties/title" }
+      }
+    },
+    "tests": [
+      {
+        "description": "empty object is valid",
+        "data": {},
+        "valid": true
+      },
+      {
+        "description": "string is valid",
+        "data": { "title": "foo" },
+        "valid": true
+      },
+      {
+        "description": "number is invalid",
+        "data": { "title": 1 },
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/issues/70_1_recursive_hash_ref_in_remote_ref.json
+++ b/test/ajv-spec/tests/issues/70_1_recursive_hash_ref_in_remote_ref.json
@@ -1,0 +1,57 @@
+[
+  {
+    "description": "hash ref inside hash ref in remote ref (#70, was passing)",
+    "schema": {
+      "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0"
+    },
+    "tests": [
+      { "data": 1, "valid": true, "description": "positive integer is valid" },
+      { "data": 0, "valid": true, "description": "zero is valid" },
+      { "data": -1, "valid": false, "description": "negative integer is invalid" }
+    ]
+  },
+  {
+    "description": "hash ref inside hash ref in remote ref with id (#70, was passing)",
+    "schema": {
+      "$id": "http://example.com/my_schema_2.json",
+      "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0"
+    },
+    "tests": [
+      { "data": 1, "valid": true, "description": "positive integer is valid" },
+      { "data": 0, "valid": true, "description": "zero is valid" },
+      { "data": -1, "valid": false, "description": "negative integer is invalid" }
+    ]
+  },
+  {
+    "description": "local hash ref with remote hash ref without inner hash ref (#70, was passing)",
+    "schema": {
+      "definitions": {
+        "a": { "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0" }
+      },
+      "properties": {
+        "b": { "$ref": "#/definitions/a" }
+      }
+    },
+    "tests": [
+      { "data": { "b": 1 }, "valid": true, "description": "positive integer is valid" },
+      { "data": { "b": 0 }, "valid": true, "description": "zero is valid" },
+      { "data": { "b": -1 }, "valid": false, "description": "negative integer is invalid" }
+    ]
+  },
+  {
+    "description": "local hash ref with remote hash ref that has inner hash ref (#70)",
+    "schema": {
+      "definitions": {
+        "a": { "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0" }
+      },
+      "properties": {
+        "b": { "$ref": "#/definitions/a" }
+      }
+    },
+    "tests": [
+      { "data": { "b": 1 }, "valid": true, "description": "positive integer is valid" },
+      { "data": { "b": 0 }, "valid": true, "description": "zero is valid" },
+      { "data": { "b": -1 }, "valid": false, "description": "negative integer is invalid" }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/issues/70_swagger_schema.json
+++ b/test/ajv-spec/tests/issues/70_swagger_schema.json
@@ -1,0 +1,1615 @@
+[
+  {
+    "description": "Swagger api schema does not compile (#70)",
+    "schema": {
+      "title": "A JSON Schema for Swagger 2.0 API.",
+      "$id": "http://swagger.io/v2/schema.json#",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [
+        "swagger",
+        "info",
+        "paths"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "swagger": {
+          "type": "string",
+          "enum": [
+            "2.0"
+          ],
+          "description": "The Swagger version of this document."
+        },
+        "info": {
+          "$ref": "#/definitions/info"
+        },
+        "host": {
+          "type": "string",
+          "pattern": "^[^{}/ :\\\\]+(?::\\d+)?$",
+          "description": "The host (name or ip) of the API. Example: 'swagger.io'"
+        },
+        "basePath": {
+          "type": "string",
+          "pattern": "^/",
+          "description": "The base path to the API. Example: '/api'."
+        },
+        "schemes": {
+          "$ref": "#/definitions/schemesList"
+        },
+        "consumes": {
+          "description": "A list of MIME types accepted by the API.",
+          "$ref": "#/definitions/mediaTypeList"
+        },
+        "produces": {
+          "description": "A list of MIME types the API can produce.",
+          "$ref": "#/definitions/mediaTypeList"
+        },
+        "paths": {
+          "$ref": "#/definitions/paths"
+        },
+        "definitions": {
+          "$ref": "#/definitions/definitions"
+        },
+        "parameters": {
+          "$ref": "#/definitions/parameterDefinitions"
+        },
+        "responses": {
+          "$ref": "#/definitions/responseDefinitions"
+        },
+        "security": {
+          "$ref": "#/definitions/security"
+        },
+        "securityDefinitions": {
+          "$ref": "#/definitions/securityDefinitions"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/tag"
+          },
+          "uniqueItems": true
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/externalDocs"
+        }
+      },
+      "definitions": {
+        "info": {
+          "type": "object",
+          "description": "General information about the API.",
+          "required": [
+            "version",
+            "title"
+          ],
+          "additionalProperties": false,
+          "patternProperties": {
+            "^x-": {
+              "$ref": "#/definitions/vendorExtension"
+            }
+          },
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "A unique and precise title of the API."
+            },
+            "version": {
+              "type": "string",
+              "description": "A semantic version number of the API."
+            },
+            "description": {
+              "type": "string",
+              "description": "A longer description of the API. Should be different from the title.  GitHub Flavored Markdown is allowed."
+            },
+            "termsOfService": {
+              "type": "string",
+              "description": "The terms of service for the API."
+            },
+            "contact": {
+              "$ref": "#/definitions/contact"
+            },
+            "license": {
+              "$ref": "#/definitions/license"
+            }
+          }
+        },
+        "contact": {
+          "type": "object",
+          "description": "Contact information for the owners of the API.",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The identifying name of the contact person/organization."
+            },
+            "url": {
+              "type": "string",
+              "description": "The URL pointing to the contact information.",
+              "format": "uri"
+            },
+            "email": {
+              "type": "string",
+              "description": "The email address of the contact person/organization.",
+              "format": "email"
+            }
+          },
+          "patternProperties": {
+            "^x-": {
+              "$ref": "#/definitions/vendorExtension"
+            }
+          }
+        },
+        "license": {
+          "type": "object",
+          "required": [
+            "name"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The name of the license type. It's encouraged to use an OSI compatible license."
+            },
+            "url": {
+              "type": "string",
+              "description": "The URL pointing to the license.",
+              "format": "uri"
+            }
+          },
+          "patternProperties": {
+            "^x-": {
+              "$ref": "#/definitions/vendorExtension"
+            }
+          }
+        },
+        "paths": {
+          "type": "object",
+          "description": "Relative paths to the individual endpoints. They must be relative to the 'basePath'.",
+          "patternProperties": {
+            "^x-": {
+              "$ref": "#/definitions/vendorExtension"
+            },
+            "^/": {
+              "$ref": "#/definitions/pathItem"
+            }
+          },
+          "additionalProperties": false
+        },
+        "definitions": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/schema"
+          },
+          "description": "One or more JSON objects describing the schemas being consumed and produced by the API."
+        },
+        "parameterDefinitions": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/parameter"
+          },
+          "description": "One or more JSON representations for parameters"
+        },
+        "responseDefinitions": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/response"
+          },
+          "description": "One or more JSON representations for parameters"
+        },
+        "externalDocs": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "information about external documentation",
+          "required": [
+            "url"
+          ],
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          },
+          "patternProperties": {
+            "^x-": {
+              "$ref": "#/definitions/vendorExtension"
+            }
+          }
+        },
+        "examples": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "mimeType": {
+          "type": "string",
+          "description": "The MIME type of the HTTP message."
+        },
+        "operation": {
+          "type": "object",
+          "required": [
+            "responses"
+          ],
+          "additionalProperties": false,
+          "patternProperties": {
+            "^x-": {
+              "$ref": "#/definitions/vendorExtension"
+            }
+          },
+          "properties": {
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "uniqueItems": true
+            },
+            "summary": {
+              "type": "string",
+              "description": "A brief summary of the operation."
+            },
+            "description": {
+              "type": "string",
+              "description": "A longer description of the operation, GitHub Flavored Markdown is allowed."
+            },
+            "externalDocs": {
+              "$ref": "#/definitions/externalDocs"
+            },
+            "operationId": {
+              "type": "string",
+              "description": "A unique identifier of the operation."
+            },
+            "produces": {
+              "description": "A list of MIME types the API can produce.",
+              "$ref": "#/definitions/mediaTypeList"
+            },
+            "consumes": {
+              "description": "A list of MIME types the API can consume.",
+              "$ref": "#/definitions/mediaTypeList"
+            },
+            "parameters": {
+              "$ref": "#/definitions/parametersList"
+            },
+            "responses": {
+              "$ref": "#/definitions/responses"
+            },
+            "schemes": {
+              "$ref": "#/definitions/schemesList"
+            },
+            "deprecated": {
+              "type": "boolean",
+              "default": false
+            },
+            "security": {
+              "$ref": "#/definitions/security"
+            }
+          }
+        },
+        "pathItem": {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^x-": {
+              "$ref": "#/definitions/vendorExtension"
+            }
+          },
+          "properties": {
+            "$ref": {
+              "type": "string"
+            },
+            "get": {
+              "$ref": "#/definitions/operation"
+            },
+            "put": {
+              "$ref": "#/definitions/operation"
+            },
+            "post": {
+              "$ref": "#/definitions/operation"
+            },
+            "delete": {
+              "$ref": "#/definitions/operation"
+            },
+            "options": {
+              "$ref": "#/definitions/operation"
+            },
+            "head": {
+              "$ref": "#/definitions/operation"
+            },
+            "patch": {
+              "$ref": "#/definitions/operation"
+            },
+            "parameters": {
+              "$ref": "#/definitions/parametersList"
+            }
+          }
+        },
+        "responses": {
+          "type": "object",
+          "description": "Response objects names can either be any valid HTTP status code or 'default'.",
+          "minProperties": 1,
+          "additionalProperties": false,
+          "patternProperties": {
+            "^([0-9]{3})$|^(default)$": {
+              "$ref": "#/definitions/responseValue"
+            },
+            "^x-": {
+              "$ref": "#/definitions/vendorExtension"
+            }
+          },
+          "not": {
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+              "^x-": {
+                "$ref": "#/definitions/vendorExtension"
+              }
+            }
+          }
+        },
+        "responseValue": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/response"
+            },
+            {
+              "$ref": "#/definitions/jsonReference"
+            }
+          ]
+        },
+        "response": {
+          "type": "object",
+          "required": [
+            "description"
+          ],
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "schema": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/schema"
+                },
+                {
+                  "$ref": "#/definitions/fileSchema"
+                }
+              ]
+            },
+            "headers": {
+              "$ref": "#/definitions/headers"
+            },
+            "examples": {
+              "$ref": "#/definitions/examples"
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {
+            "^x-": {
+              "$ref": "#/definitions/vendorExtension"
+            }
+          }
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/header"
+          }
+        },
+        "header": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "string",
+                "number",
+                "integer",
+                "boolean",
+                "array"
+              ]
+            },
+            "format": {
+              "type": "string"
+            },
+            "items": {
+              "$ref": "#/definitions/primitivesItems"
+            },
+            "collectionFormat": {
+              "$ref": "#/definitions/collectionFormat"
+            },
+            "default": {
+              "$ref": "#/definitions/default"
+            },
+            "maximum": {
+              "$ref": "#/definitions/maximum"
+            },
+            "exclusiveMaximum": {
+              "$ref": "#/definitions/exclusiveMaximum"
+            },
+            "minimum": {
+              "$ref": "#/definitions/minimum"
+            },
+            "exclusiveMinimum": {
+              "$ref": "#/definitions/exclusiveMinimum"
+            },
+            "maxLength": {
+              "$ref": "#/definitions/maxLength"
+            },
+            "minLength": {
+              "$ref": "#/definitions/minLength"
+            },
+            "pattern": {
+              "$ref": "#/definitions/pattern"
+            },
+            "maxItems": {
+              "$ref": "#/definitions/maxItems"
+            },
+            "minItems": {
+              "$ref": "#/definitions/minItems"
+            },
+            "uniqueItems": {
+              "$ref": "#/definitions/uniqueItems"
+            },
+            "enum": {
+              "$ref": "#/definitions/enum"
+            },
+            "multipleOf": {
+              "$ref": "#/definitions/multipleOf"
+            },
+            "description": {
+              "type": "string"
+            }
+          },
+          "patternProperties": {
+            "^x-": {
+              "$ref": "#/definitions/vendorExtension"
+            }
+          }
+        },
+        "vendorExtension": {
+          "description": "Any property starting with x- is valid.",
+          "additionalProperties": true,
+          "additionalItems": true
+        },
+        "bodyParameter": {
+          "type": "object",
+          "required": [
+            "name",
+            "in",
+            "schema"
+          ],
+          "patternProperties": {
+            "^x-": {
+              "$ref": "#/definitions/vendorExtension"
+            }
+          },
+          "properties": {
+            "description": {
+              "type": "string",
+              "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
+            },
+            "name": {
+              "type": "string",
+              "description": "The name of the parameter."
+            },
+            "in": {
+              "type": "string",
+              "description": "Determines the location of the parameter.",
+              "enum": [
+                "body"
+              ]
+            },
+            "required": {
+              "type": "boolean",
+              "description": "Determines whether or not this parameter is required or optional.",
+              "default": false
+            },
+            "schema": {
+              "$ref": "#/definitions/schema"
+            }
+          },
+          "additionalProperties": false
+        },
+        "headerParameterSubSchema": {
+          "additionalProperties": false,
+          "patternProperties": {
+            "^x-": {
+              "$ref": "#/definitions/vendorExtension"
+            }
+          },
+          "properties": {
+            "required": {
+              "type": "boolean",
+              "description": "Determines whether or not this parameter is required or optional.",
+              "default": false
+            },
+            "in": {
+              "type": "string",
+              "description": "Determines the location of the parameter.",
+              "enum": [
+                "header"
+              ]
+            },
+            "description": {
+              "type": "string",
+              "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
+            },
+            "name": {
+              "type": "string",
+              "description": "The name of the parameter."
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "string",
+                "number",
+                "boolean",
+                "integer",
+                "array"
+              ]
+            },
+            "format": {
+              "type": "string"
+            },
+            "items": {
+              "$ref": "#/definitions/primitivesItems"
+            },
+            "collectionFormat": {
+              "$ref": "#/definitions/collectionFormat"
+            },
+            "default": {
+              "$ref": "#/definitions/default"
+            },
+            "maximum": {
+              "$ref": "#/definitions/maximum"
+            },
+            "exclusiveMaximum": {
+              "$ref": "#/definitions/exclusiveMaximum"
+            },
+            "minimum": {
+              "$ref": "#/definitions/minimum"
+            },
+            "exclusiveMinimum": {
+              "$ref": "#/definitions/exclusiveMinimum"
+            },
+            "maxLength": {
+              "$ref": "#/definitions/maxLength"
+            },
+            "minLength": {
+              "$ref": "#/definitions/minLength"
+            },
+            "pattern": {
+              "$ref": "#/definitions/pattern"
+            },
+            "maxItems": {
+              "$ref": "#/definitions/maxItems"
+            },
+            "minItems": {
+              "$ref": "#/definitions/minItems"
+            },
+            "uniqueItems": {
+              "$ref": "#/definitions/uniqueItems"
+            },
+            "enum": {
+              "$ref": "#/definitions/enum"
+            },
+            "multipleOf": {
+              "$ref": "#/definitions/multipleOf"
+            }
+          }
+        },
+        "queryParameterSubSchema": {
+          "additionalProperties": false,
+          "patternProperties": {
+            "^x-": {
+              "$ref": "#/definitions/vendorExtension"
+            }
+          },
+          "properties": {
+            "required": {
+              "type": "boolean",
+              "description": "Determines whether or not this parameter is required or optional.",
+              "default": false
+            },
+            "in": {
+              "type": "string",
+              "description": "Determines the location of the parameter.",
+              "enum": [
+                "query"
+              ]
+            },
+            "description": {
+              "type": "string",
+              "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
+            },
+            "name": {
+              "type": "string",
+              "description": "The name of the parameter."
+            },
+            "allowEmptyValue": {
+              "type": "boolean",
+              "default": false,
+              "description": "allows sending a parameter by name only or with an empty value."
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "string",
+                "number",
+                "boolean",
+                "integer",
+                "array"
+              ]
+            },
+            "format": {
+              "type": "string"
+            },
+            "items": {
+              "$ref": "#/definitions/primitivesItems"
+            },
+            "collectionFormat": {
+              "$ref": "#/definitions/collectionFormatWithMulti"
+            },
+            "default": {
+              "$ref": "#/definitions/default"
+            },
+            "maximum": {
+              "$ref": "#/definitions/maximum"
+            },
+            "exclusiveMaximum": {
+              "$ref": "#/definitions/exclusiveMaximum"
+            },
+            "minimum": {
+              "$ref": "#/definitions/minimum"
+            },
+            "exclusiveMinimum": {
+              "$ref": "#/definitions/exclusiveMinimum"
+            },
+            "maxLength": {
+              "$ref": "#/definitions/maxLength"
+            },
+            "minLength": {
+              "$ref": "#/definitions/minLength"
+            },
+            "pattern": {
+              "$ref": "#/definitions/pattern"
+            },
+            "maxItems": {
+              "$ref": "#/definitions/maxItems"
+            },
+            "minItems": {
+              "$ref": "#/definitions/minItems"
+            },
+            "uniqueItems": {
+              "$ref": "#/definitions/uniqueItems"
+            },
+            "enum": {
+              "$ref": "#/definitions/enum"
+            },
+            "multipleOf": {
+              "$ref": "#/definitions/multipleOf"
+            }
+          }
+        },
+        "formDataParameterSubSchema": {
+          "additionalProperties": false,
+          "patternProperties": {
+            "^x-": {
+              "$ref": "#/definitions/vendorExtension"
+            }
+          },
+          "properties": {
+            "required": {
+              "type": "boolean",
+              "description": "Determines whether or not this parameter is required or optional.",
+              "default": false
+            },
+            "in": {
+              "type": "string",
+              "description": "Determines the location of the parameter.",
+              "enum": [
+                "formData"
+              ]
+            },
+            "description": {
+              "type": "string",
+              "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
+            },
+            "name": {
+              "type": "string",
+              "description": "The name of the parameter."
+            },
+            "allowEmptyValue": {
+              "type": "boolean",
+              "default": false,
+              "description": "allows sending a parameter by name only or with an empty value."
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "string",
+                "number",
+                "boolean",
+                "integer",
+                "array",
+                "file"
+              ]
+            },
+            "format": {
+              "type": "string"
+            },
+            "items": {
+              "$ref": "#/definitions/primitivesItems"
+            },
+            "collectionFormat": {
+              "$ref": "#/definitions/collectionFormatWithMulti"
+            },
+            "default": {
+              "$ref": "#/definitions/default"
+            },
+            "maximum": {
+              "$ref": "#/definitions/maximum"
+            },
+            "exclusiveMaximum": {
+              "$ref": "#/definitions/exclusiveMaximum"
+            },
+            "minimum": {
+              "$ref": "#/definitions/minimum"
+            },
+            "exclusiveMinimum": {
+              "$ref": "#/definitions/exclusiveMinimum"
+            },
+            "maxLength": {
+              "$ref": "#/definitions/maxLength"
+            },
+            "minLength": {
+              "$ref": "#/definitions/minLength"
+            },
+            "pattern": {
+              "$ref": "#/definitions/pattern"
+            },
+            "maxItems": {
+              "$ref": "#/definitions/maxItems"
+            },
+            "minItems": {
+              "$ref": "#/definitions/minItems"
+            },
+            "uniqueItems": {
+              "$ref": "#/definitions/uniqueItems"
+            },
+            "enum": {
+              "$ref": "#/definitions/enum"
+            },
+            "multipleOf": {
+              "$ref": "#/definitions/multipleOf"
+            }
+          }
+        },
+        "pathParameterSubSchema": {
+          "additionalProperties": false,
+          "patternProperties": {
+            "^x-": {
+              "$ref": "#/definitions/vendorExtension"
+            }
+          },
+          "required": [
+            "required"
+          ],
+          "properties": {
+            "required": {
+              "type": "boolean",
+              "enum": [
+                true
+              ],
+              "description": "Determines whether or not this parameter is required or optional."
+            },
+            "in": {
+              "type": "string",
+              "description": "Determines the location of the parameter.",
+              "enum": [
+                "path"
+              ]
+            },
+            "description": {
+              "type": "string",
+              "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
+            },
+            "name": {
+              "type": "string",
+              "description": "The name of the parameter."
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "string",
+                "number",
+                "boolean",
+                "integer",
+                "array"
+              ]
+            },
+            "format": {
+              "type": "string"
+            },
+            "items": {
+              "$ref": "#/definitions/primitivesItems"
+            },
+            "collectionFormat": {
+              "$ref": "#/definitions/collectionFormat"
+            },
+            "default": {
+              "$ref": "#/definitions/default"
+            },
+            "maximum": {
+              "$ref": "#/definitions/maximum"
+            },
+            "exclusiveMaximum": {
+              "$ref": "#/definitions/exclusiveMaximum"
+            },
+            "minimum": {
+              "$ref": "#/definitions/minimum"
+            },
+            "exclusiveMinimum": {
+              "$ref": "#/definitions/exclusiveMinimum"
+            },
+            "maxLength": {
+              "$ref": "#/definitions/maxLength"
+            },
+            "minLength": {
+              "$ref": "#/definitions/minLength"
+            },
+            "pattern": {
+              "$ref": "#/definitions/pattern"
+            },
+            "maxItems": {
+              "$ref": "#/definitions/maxItems"
+            },
+            "minItems": {
+              "$ref": "#/definitions/minItems"
+            },
+            "uniqueItems": {
+              "$ref": "#/definitions/uniqueItems"
+            },
+            "enum": {
+              "$ref": "#/definitions/enum"
+            },
+            "multipleOf": {
+              "$ref": "#/definitions/multipleOf"
+            }
+          }
+        },
+        "nonBodyParameter": {
+          "type": "object",
+          "required": [
+            "name",
+            "in",
+            "type"
+          ],
+          "oneOf": [
+            {
+              "$ref": "#/definitions/headerParameterSubSchema"
+            },
+            {
+              "$ref": "#/definitions/formDataParameterSubSchema"
+            },
+            {
+              "$ref": "#/definitions/queryParameterSubSchema"
+            },
+            {
+              "$ref": "#/definitions/pathParameterSubSchema"
+            }
+          ]
+        },
+        "parameter": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/bodyParameter"
+            },
+            {
+              "$ref": "#/definitions/nonBodyParameter"
+            }
+          ]
+        },
+        "schema": {
+          "type": "object",
+          "description": "A deterministic version of a JSON Schema object.",
+          "patternProperties": {
+            "^x-": {
+              "$ref": "#/definitions/vendorExtension"
+            }
+          },
+          "properties": {
+            "$ref": {
+              "type": "string"
+            },
+            "format": {
+              "type": "string"
+            },
+            "title": {
+              "$ref": "http://json-schema.org/draft-07/schema#/properties/title"
+            },
+            "description": {
+              "$ref": "http://json-schema.org/draft-07/schema#/properties/description"
+            },
+            "default": {
+              "$ref": "http://json-schema.org/draft-07/schema#/properties/default"
+            },
+            "multipleOf": {
+              "$ref": "http://json-schema.org/draft-07/schema#/properties/multipleOf"
+            },
+            "maximum": {
+              "$ref": "http://json-schema.org/draft-07/schema#/properties/maximum"
+            },
+            "exclusiveMaximum": {
+              "$ref": "http://json-schema.org/draft-07/schema#/properties/exclusiveMaximum"
+            },
+            "minimum": {
+              "$ref": "http://json-schema.org/draft-07/schema#/properties/minimum"
+            },
+            "exclusiveMinimum": {
+              "$ref": "http://json-schema.org/draft-07/schema#/properties/exclusiveMinimum"
+            },
+            "maxLength": {
+              "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeInteger"
+            },
+            "minLength": {
+              "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0"
+            },
+            "pattern": {
+              "$ref": "http://json-schema.org/draft-07/schema#/properties/pattern"
+            },
+            "maxItems": {
+              "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeInteger"
+            },
+            "minItems": {
+              "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0"
+            },
+            "uniqueItems": {
+              "$ref": "http://json-schema.org/draft-07/schema#/properties/uniqueItems"
+            },
+            "maxProperties": {
+              "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeInteger"
+            },
+            "minProperties": {
+              "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0"
+            },
+            "required": {
+              "$ref": "http://json-schema.org/draft-07/schema#/definitions/stringArray"
+            },
+            "enum": {
+              "$ref": "http://json-schema.org/draft-07/schema#/properties/enum"
+            },
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/schema"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "default": {}
+            },
+            "type": {
+              "$ref": "http://json-schema.org/draft-07/schema#/properties/type"
+            },
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/schema"
+                },
+                {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "$ref": "#/definitions/schema"
+                  }
+                }
+              ],
+              "default": {}
+            },
+            "allOf": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/schema"
+              }
+            },
+            "properties": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/schema"
+              },
+              "default": {}
+            },
+            "discriminator": {
+              "type": "string"
+            },
+            "readOnly": {
+              "type": "boolean",
+              "default": false
+            },
+            "xml": {
+              "$ref": "#/definitions/xml"
+            },
+            "externalDocs": {
+              "$ref": "#/definitions/externalDocs"
+            },
+            "example": {}
+          },
+          "additionalProperties": false
+        },
+        "fileSchema": {
+          "type": "object",
+          "description": "A deterministic version of a JSON Schema object.",
+          "patternProperties": {
+            "^x-": {
+              "$ref": "#/definitions/vendorExtension"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "format": {
+              "type": "string"
+            },
+            "title": {
+              "$ref": "http://json-schema.org/draft-07/schema#/properties/title"
+            },
+            "description": {
+              "$ref": "http://json-schema.org/draft-07/schema#/properties/description"
+            },
+            "default": {
+              "$ref": "http://json-schema.org/draft-07/schema#/properties/default"
+            },
+            "required": {
+              "$ref": "http://json-schema.org/draft-07/schema#/definitions/stringArray"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "readOnly": {
+              "type": "boolean",
+              "default": false
+            },
+            "externalDocs": {
+              "$ref": "#/definitions/externalDocs"
+            },
+            "example": {}
+          },
+          "additionalProperties": false
+        },
+        "primitivesItems": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "string",
+                "number",
+                "integer",
+                "boolean",
+                "array"
+              ]
+            },
+            "format": {
+              "type": "string"
+            },
+            "items": {
+              "$ref": "#/definitions/primitivesItems"
+            },
+            "collectionFormat": {
+              "$ref": "#/definitions/collectionFormat"
+            },
+            "default": {
+              "$ref": "#/definitions/default"
+            },
+            "maximum": {
+              "$ref": "#/definitions/maximum"
+            },
+            "exclusiveMaximum": {
+              "$ref": "#/definitions/exclusiveMaximum"
+            },
+            "minimum": {
+              "$ref": "#/definitions/minimum"
+            },
+            "exclusiveMinimum": {
+              "$ref": "#/definitions/exclusiveMinimum"
+            },
+            "maxLength": {
+              "$ref": "#/definitions/maxLength"
+            },
+            "minLength": {
+              "$ref": "#/definitions/minLength"
+            },
+            "pattern": {
+              "$ref": "#/definitions/pattern"
+            },
+            "maxItems": {
+              "$ref": "#/definitions/maxItems"
+            },
+            "minItems": {
+              "$ref": "#/definitions/minItems"
+            },
+            "uniqueItems": {
+              "$ref": "#/definitions/uniqueItems"
+            },
+            "enum": {
+              "$ref": "#/definitions/enum"
+            },
+            "multipleOf": {
+              "$ref": "#/definitions/multipleOf"
+            }
+          },
+          "patternProperties": {
+            "^x-": {
+              "$ref": "#/definitions/vendorExtension"
+            }
+          }
+        },
+        "security": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/securityRequirement"
+          },
+          "uniqueItems": true
+        },
+        "securityRequirement": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true
+          }
+        },
+        "xml": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "namespace": {
+              "type": "string"
+            },
+            "prefix": {
+              "type": "string"
+            },
+            "attribute": {
+              "type": "boolean",
+              "default": false
+            },
+            "wrapped": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "patternProperties": {
+            "^x-": {
+              "$ref": "#/definitions/vendorExtension"
+            }
+          }
+        },
+        "tag": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "externalDocs": {
+              "$ref": "#/definitions/externalDocs"
+            }
+          },
+          "patternProperties": {
+            "^x-": {
+              "$ref": "#/definitions/vendorExtension"
+            }
+          }
+        },
+        "securityDefinitions": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/basicAuthenticationSecurity"
+              },
+              {
+                "$ref": "#/definitions/apiKeySecurity"
+              },
+              {
+                "$ref": "#/definitions/oauth2ImplicitSecurity"
+              },
+              {
+                "$ref": "#/definitions/oauth2PasswordSecurity"
+              },
+              {
+                "$ref": "#/definitions/oauth2ApplicationSecurity"
+              },
+              {
+                "$ref": "#/definitions/oauth2AccessCodeSecurity"
+              }
+            ]
+          }
+        },
+        "basicAuthenticationSecurity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "basic"
+              ]
+            },
+            "description": {
+              "type": "string"
+            }
+          },
+          "patternProperties": {
+            "^x-": {
+              "$ref": "#/definitions/vendorExtension"
+            }
+          }
+        },
+        "apiKeySecurity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "name",
+            "in"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "apiKey"
+              ]
+            },
+            "name": {
+              "type": "string"
+            },
+            "in": {
+              "type": "string",
+              "enum": [
+                "header",
+                "query"
+              ]
+            },
+            "description": {
+              "type": "string"
+            }
+          },
+          "patternProperties": {
+            "^x-": {
+              "$ref": "#/definitions/vendorExtension"
+            }
+          }
+        },
+        "oauth2ImplicitSecurity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "flow",
+            "authorizationUrl"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "oauth2"
+              ]
+            },
+            "flow": {
+              "type": "string",
+              "enum": [
+                "implicit"
+              ]
+            },
+            "scopes": {
+              "$ref": "#/definitions/oauth2Scopes"
+            },
+            "authorizationUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "description": {
+              "type": "string"
+            }
+          },
+          "patternProperties": {
+            "^x-": {
+              "$ref": "#/definitions/vendorExtension"
+            }
+          }
+        },
+        "oauth2PasswordSecurity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "flow",
+            "tokenUrl"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "oauth2"
+              ]
+            },
+            "flow": {
+              "type": "string",
+              "enum": [
+                "password"
+              ]
+            },
+            "scopes": {
+              "$ref": "#/definitions/oauth2Scopes"
+            },
+            "tokenUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "description": {
+              "type": "string"
+            }
+          },
+          "patternProperties": {
+            "^x-": {
+              "$ref": "#/definitions/vendorExtension"
+            }
+          }
+        },
+        "oauth2ApplicationSecurity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "flow",
+            "tokenUrl"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "oauth2"
+              ]
+            },
+            "flow": {
+              "type": "string",
+              "enum": [
+                "application"
+              ]
+            },
+            "scopes": {
+              "$ref": "#/definitions/oauth2Scopes"
+            },
+            "tokenUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "description": {
+              "type": "string"
+            }
+          },
+          "patternProperties": {
+            "^x-": {
+              "$ref": "#/definitions/vendorExtension"
+            }
+          }
+        },
+        "oauth2AccessCodeSecurity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "flow",
+            "authorizationUrl",
+            "tokenUrl"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "oauth2"
+              ]
+            },
+            "flow": {
+              "type": "string",
+              "enum": [
+                "accessCode"
+              ]
+            },
+            "scopes": {
+              "$ref": "#/definitions/oauth2Scopes"
+            },
+            "authorizationUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "tokenUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "description": {
+              "type": "string"
+            }
+          },
+          "patternProperties": {
+            "^x-": {
+              "$ref": "#/definitions/vendorExtension"
+            }
+          }
+        },
+        "oauth2Scopes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "mediaTypeList": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/mimeType"
+          },
+          "uniqueItems": true
+        },
+        "parametersList": {
+          "type": "array",
+          "description": "The parameters needed to send a valid API call.",
+          "additionalItems": false,
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/parameter"
+              },
+              {
+                "$ref": "#/definitions/jsonReference"
+              }
+            ]
+          },
+          "uniqueItems": true
+        },
+        "schemesList": {
+          "type": "array",
+          "description": "The transfer protocol of the API.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "http",
+              "https",
+              "ws",
+              "wss"
+            ]
+          },
+          "uniqueItems": true
+        },
+        "collectionFormat": {
+          "type": "string",
+          "enum": [
+            "csv",
+            "ssv",
+            "tsv",
+            "pipes"
+          ],
+          "default": "csv"
+        },
+        "collectionFormatWithMulti": {
+          "type": "string",
+          "enum": [
+            "csv",
+            "ssv",
+            "tsv",
+            "pipes",
+            "multi"
+          ],
+          "default": "csv"
+        },
+        "title": {
+          "$ref": "http://json-schema.org/draft-07/schema#/properties/title"
+        },
+        "description": {
+          "$ref": "http://json-schema.org/draft-07/schema#/properties/description"
+        },
+        "default": {
+          "$ref": "http://json-schema.org/draft-07/schema#/properties/default"
+        },
+        "multipleOf": {
+          "$ref": "http://json-schema.org/draft-07/schema#/properties/multipleOf"
+        },
+        "maximum": {
+          "$ref": "http://json-schema.org/draft-07/schema#/properties/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "http://json-schema.org/draft-07/schema#/properties/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "http://json-schema.org/draft-07/schema#/properties/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "http://json-schema.org/draft-07/schema#/properties/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeInteger"
+        },
+        "minLength": {
+          "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0"
+        },
+        "pattern": {
+          "$ref": "http://json-schema.org/draft-07/schema#/properties/pattern"
+        },
+        "maxItems": {
+          "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeInteger"
+        },
+        "minItems": {
+          "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0"
+        },
+        "uniqueItems": {
+          "$ref": "http://json-schema.org/draft-07/schema#/properties/uniqueItems"
+        },
+        "enum": {
+          "$ref": "http://json-schema.org/draft-07/schema#/properties/enum"
+        },
+        "jsonReference": {
+          "type": "object",
+          "required": [
+            "$ref"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "$ref": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "empty object is invalid",
+        "data": {},
+        "valid": false
+      },
+      {
+        "description": "minimal valid object",
+        "data": {
+          "swagger": "2.0",
+          "info": {
+            "title": "sample api definition",
+            "version": "0.1"
+          },
+          "paths": {}
+        },
+        "valid": true
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/issues/861_empty_propertynames.json
+++ b/test/ajv-spec/tests/issues/861_empty_propertynames.json
@@ -1,0 +1,23 @@
+[
+  {
+    "description": "propertyNames with empty schema (#861)",
+    "schema": {
+      "properties": {
+        "foo": {"type": "string"}
+      },
+      "propertyNames": {}
+    },
+    "tests": [
+      {
+        "description": "valid",
+        "data": {"foo": "bar"},
+        "valid": true
+      },
+      {
+        "description": "invalid",
+        "data": {"foo": 1},
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/issues/87_$_property.json
+++ b/test/ajv-spec/tests/issues/87_$_property.json
@@ -1,0 +1,17 @@
+[
+  {
+    "description": "$ in properties (#87)",
+    "schema": {
+      "properties": {
+        "$": { "type": "string" }
+      }
+    },
+    "tests": [
+      {
+        "description": "valid",
+        "data": { "$": "foo" },
+        "valid": true
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/issues/94_dependencies_fail.json
+++ b/test/ajv-spec/tests/issues/94_dependencies_fail.json
@@ -1,0 +1,54 @@
+[
+  {
+    "description": "second dependency is not checked (#94)",
+    "schema": {
+      "dependencies": {
+        "bar" : ["baz"],
+        "foo" : ["bar"]
+      }
+    },
+    "tests": [
+      {
+        "description": "object with only foo is invalid (bar is missing)",
+        "data": { "foo": 1 },
+        "valid": false
+      },
+      {
+        "description": "object with foo and bar is invalid (baz is missing)",
+        "data": { "foo": 1, "bar": 2 },
+        "valid": false
+      },
+      {
+        "description": "object with foo, bar and baz is valid",
+        "data": { "foo": 1, "bar": 2, "baz": 3 },
+        "valid": true
+      }
+    ]
+  },
+  {
+    "description": "second dependency is checked when order is changed",
+    "schema": {
+      "dependencies": {
+        "foo" : ["bar"],
+        "bar" : ["baz"]
+      }
+    },
+    "tests": [
+      {
+        "description": "object with only foo is invalid (bar is missing)",
+        "data": { "foo": 1 },
+        "valid": false
+      },
+      {
+        "description": "object with foo and bar is invalid (baz is missing)",
+        "data": { "foo": 1, "bar": 2 },
+        "valid": false
+      },
+      {
+        "description": "object with foo, bar and baz is valid",
+        "data": { "foo": 1, "bar": 2, "baz": 3 },
+        "valid": true
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/rules/allOf.json
+++ b/test/ajv-spec/tests/rules/allOf.json
@@ -1,0 +1,75 @@
+[
+  {
+    "description": "allOf with one empty schema",
+    "schema": {
+      "allOf": [
+        {}
+      ]
+    },
+    "tests": [
+      {
+        "description": "any data is valid",
+        "data": 1,
+        "valid": true
+      }
+    ]
+  },
+  {
+    "description": "allOf with two empty schemas",
+    "schema": {
+      "allOf": [
+        {},
+        {}
+      ]
+    },
+    "tests": [
+      {
+        "description": "any data is valid",
+        "data": 1,
+        "valid": true
+      }
+    ]
+  },
+  {
+    "description": "allOf with two schemas, the first is empty",
+    "schema": {
+      "allOf": [
+        {},
+        { "type": "number" }
+      ]
+    },
+    "tests": [
+      {
+        "description": "number is valid",
+        "data": 1,
+        "valid": true
+      },
+      {
+        "description": "string is invalid",
+        "data": "foo",
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "allOf with two schemas, the second is empty",
+    "schema": {
+      "allOf": [
+        { "type": "number" },
+        {}
+      ]
+    },
+    "tests": [
+      {
+        "description": "number is valid",
+        "data": 1,
+        "valid": true
+      },
+      {
+        "description": "string is invalid",
+        "data": "foo",
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/rules/anyOf.json
+++ b/test/ajv-spec/tests/rules/anyOf.json
@@ -1,0 +1,23 @@
+[
+  {
+    "description": "anyOf with one of schemas empty",
+    "schema": {
+      "anyOf": [
+        { "type": "number" },
+        {}
+      ]
+    },
+    "tests": [
+      {
+        "description": "string is valid",
+        "data": "foo",
+        "valid": true
+      },
+      {
+        "description": "number is valid",
+        "data": 123,
+        "valid": true
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/rules/comment.json
+++ b/test/ajv-spec/tests/rules/comment.json
@@ -1,0 +1,40 @@
+[
+  {
+    "description": "$comment keyword",
+    "schema": {
+      "$comment": "test"
+    },
+    "tests": [
+      {
+        "description": "any value is valid",
+        "data": 1,
+        "valid": true
+      }
+    ]
+  },
+  {
+    "description": "$comment keyword in subschemas",
+    "schema": {
+      "type": "object",
+      "properties": {
+        "foo": {
+          "$comment": "test"
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "empty object is valid",
+        "data": {},
+        "valid": true
+      },
+      {
+        "description": "any value of property foo is valid object is valid",
+        "data": {
+          "foo": 1
+        },
+        "valid": true
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/rules/dependencies.json
+++ b/test/ajv-spec/tests/rules/dependencies.json
@@ -1,0 +1,27 @@
+[
+  {
+    "description": "dependencies keyword with empty array",
+    "schema": {
+      "dependencies": {
+        "foo": []
+      }
+    },
+    "tests": [
+      {
+        "description": "object with property is valid",
+        "data": { "foo": 1 },
+        "valid": true
+      },
+      {
+        "description": "empty object is valid",
+        "data": {},
+        "valid": true
+      },
+      {
+        "description": "non-object is valid",
+        "data": 1,
+        "valid": true
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/rules/format.json
+++ b/test/ajv-spec/tests/rules/format.json
@@ -1,0 +1,745 @@
+[
+  {
+    "description": "whitelisted unknown format is valid",
+    "schema": {
+      "format": "allowedUnknown"
+    },
+    "tests": [
+      {
+        "description": "any string is valid",
+        "data": "any value",
+        "valid": true
+      }
+    ]
+  },
+  {
+    "description": "format: regex",
+    "schema": {
+      "format": "regex"
+    },
+    "tests": [
+      {
+        "description": "valid regex",
+        "data": "[0-9]",
+        "valid": true
+      },
+      {
+        "description": "invalid regex",
+        "data": "[9-0]",
+        "valid": false
+      },
+      {
+        "description": "not string is valid",
+        "data": 123,
+        "valid": true
+      }
+    ]
+  },
+  {
+    "description": "format: uri",
+    "schema": {
+      "format": "uri"
+    },
+    "tests": [
+      {
+        "description": "valid uri",
+        "data": "urn:isbn:978-3-531-18621-4",
+        "valid": true
+      },
+      {
+        "description": "invalid relative uri-reference",
+        "data": "/abc",
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "format: uri-template",
+    "schema": {
+      "format": "uri-template"
+    },
+    "tests": [
+      {
+        "description": "valid uri-template",
+        "data": "http://example.com/dictionary/{term:1}/{term}",
+        "valid": true
+      },
+      {
+        "description": "invalid uri-template",
+        "data": "http://example.com/dictionary/{term:1}/{term",
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "format: hostname",
+    "schema": {
+      "format": "hostname"
+    },
+    "tests": [
+      {
+        "description": "valid hostname",
+        "data": "123.example.com",
+        "valid": true
+      },
+      {
+        "description": "valid hostname - trailing dot",
+        "data": "123.example.com.",
+        "valid": true
+      },
+      {
+        "description": "valid hostname - single label",
+        "data": "localhost",
+        "valid": true
+      },
+      {
+        "description": "valid hostname - single label with trailing dot",
+        "data": "localhost.",
+        "valid": true
+      },
+      {
+        "description": "valid hostname #312",
+        "data": "lead-routing-qa.lvuucj.0001.use1.cache.amazonaws.com",
+        "valid": true
+      },
+      {
+        "description": "valid hostname - maximum length label (63 chars)",
+        "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.example.com",
+        "valid": true
+      },
+      {
+        "description": "invalid hostname - label too long (64 chars)",
+        "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.example.com",
+        "valid": false
+      },
+      {
+        "description": "valid hostname - maximum length hostname (255 octets)",
+        "data": "abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxy.example.com",
+        "valid": true
+      },
+      {
+        "description": "valid hostname - maximum length hostname (255 octets) with trailing dot",
+        "data": "abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxy.example.com.",
+        "valid": true
+      },
+      {
+        "description": "invalid hostname - hostname too long (256 octets)",
+        "data": "abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.example.com",
+        "valid": false
+      },
+      {
+        "description": "invalid hostname - hostname too long (256 octets) with trailing dot",
+        "data": "abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.example.com.",
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "validation of URL strings",
+    "schema": {"format": "url"},
+    "tests": [
+      {
+        "data": "http://foo.com/blah_blah",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://foo.com/blah_blah/",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://foo.com/blah_blah_(wikipedia)",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://foo.com/blah_blah_(wikipedia)_(again)",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://www.example.com/wpstyle/?p=364",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "https://www.example.com/foo/?bar=baz&inga=42&quux",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://✪df.ws/123",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://userid:password@example.com:8080",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://userid:password@example.com:8080/",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://userid@example.com",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://userid@example.com/",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://userid@example.com:8080",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://userid@example.com:8080/",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://userid:password@example.com",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://userid:password@example.com/",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://142.42.1.1/",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://142.42.1.1:8080/",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://➡.ws/䨹",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://⌘.ws",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://⌘.ws/",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://foo.com/blah_(wikipedia)#cite-1",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://foo.com/blah_(wikipedia)_blah#cite-1",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://foo.com/unicode_(✪)_in_parens",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://foo.com/(something)?after=parens",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://☺.damowmow.com/",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://code.google.com/events/#&product=browser",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://j.mp",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "ftp://foo.bar/baz",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://foo.bar/?q=Test%20URL-encoded%20stuff",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://مثال.إختبار",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://例子.测试",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://उदाहरण.परीक्षा",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://-.~_!$&'()*+,;=:%40:80%2f::::::@example.com",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://1337.net",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://a.b-c.de",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://223.255.255.254",
+        "description": "a valid URL string",
+        "valid": true
+      },
+      {
+        "data": "http://",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "http://.",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "http://..",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "http://../",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "http://?",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "http://??",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "http://??/",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "http://#",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "http://##",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "http://##/",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "http://foo.bar?q=Spaces should be encoded",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "//",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "//a",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "///a",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "///",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "http:///a",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "foo.com",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "rdar://1234",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "h://test",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "http:// shouldfail.com",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": ":// should fail",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "http://foo.bar/foo(bar)baz quux",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "ftps://foo.bar/",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "http://-error-.invalid/",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "http://a.b--c.de/",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "http://-a.b.co",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "http://a.b-.co",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "http://0.0.0.0",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "http://10.1.1.0",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "http://10.1.1.255",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "http://224.1.1.1",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "http://1.1.1.1.1",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "http://123.123.123",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "http://3628126748",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "http://.www.foo.bar/",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "http://www.foo.bar./",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "http://.www.foo.bar./",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "http://10.1.1.1",
+        "description": "an invalid URL string",
+        "valid": false
+      },
+      {
+        "data": "http://10.1.1.254",
+        "description": "an invalid URL string",
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "validation of date strings",
+    "schema": {"format": "date"},
+    "tests": [
+      {
+        "description": "a valid date string",
+        "data": "1963-06-19",
+        "valid": true
+      },
+      {
+        "description": "an invalid date string",
+        "data": "06/19/1963",
+        "valid": false
+      },
+      {
+        "description": "only RFC3339 not all of ISO 8601 are valid",
+        "data": "2013-350",
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "validation of time strings",
+    "schema": {"format": "time"},
+    "tests": [
+      {
+        "description": "a valid time",
+        "data": "12:34:56",
+        "valid": true
+      },
+      {
+        "description": "a valid time with milliseconds",
+        "data": "12:34:56.789",
+        "valid": true
+      },
+      {
+        "description": "a valid time with timezone",
+        "data": "12:34:56+01:00",
+        "valid": true
+      },
+      {
+        "description": "an invalid time format",
+        "data": "12.34.56",
+        "valid": false
+      },
+      {
+        "description": "an invalid time",
+        "data": "12:34:67",
+        "valid": false
+      },
+      {
+        "description": "a valid time (leap second)",
+        "data": "23:59:60",
+        "valid": true
+      }
+    ]
+  },
+  {
+    "description": "validation of date-time strings",
+    "schema": {"format": "date-time"},
+    "tests": [
+      {
+        "description": "a valid date-time string",
+        "data": "1963-06-19T12:13:14Z",
+        "valid": true
+      },
+      {
+        "description": "an invalid date-time string (no time)",
+        "data": "1963-06-19",
+        "valid": false
+      },
+      {
+        "description": "an invalid date-time string (additional part)",
+        "data": "1963-06-19T12:13:14ZTinvalid",
+        "valid": false
+      },
+      {
+        "description": "an invalid date-time string (invalid date)",
+        "data": "1963-20-19T12:13:14Z",
+        "valid": false
+      },
+      {
+        "description": "an invalid date-time string (invalid time)",
+        "data": "1963-06-19T12:13:67Z",
+        "valid": false
+      },
+      {
+        "description": "a valid date-time string (leap second)",
+        "data": "2016-12-31T23:59:60Z",
+        "valid": true
+      }
+    ]
+  },
+  {
+    "description": "validation of uuid strings",
+    "schema": {"format": "uuid"},
+    "tests": [
+      {
+        "description": "a valid uuid",
+        "data": "f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+        "valid": true
+      },
+      {
+        "description": "a valid uuid with uri prefix",
+        "data": "urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+        "valid": true
+      },
+      {
+        "description": "not valid uuid",
+        "data": "f81d4fae7dec11d0a76500a0c91e6bf6",
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "validation of JSON-pointer strings",
+    "schema": {"format": "json-pointer"},
+    "tests": [
+      {
+        "description": "a valid JSON-pointer",
+        "data": "/foo/bar~0/baz~1/%a",
+        "valid": true
+      },
+      {
+        "description": "empty string is valid",
+        "data": "",
+        "valid": true
+      },
+      {
+        "description": "/ is valid",
+        "data": "/",
+        "valid": true
+      },
+      {
+        "description": "not a valid JSON-pointer (~ not escaped)",
+        "data": "/foo/bar~",
+        "valid": false
+      },
+      {
+        "description": "valid JSON-pointer with empty segment",
+        "data": "/foo//bar",
+        "valid": true
+      },
+      {
+        "description": "valid JSON-pointer with the last empty segment",
+        "data": "/foo/bar/",
+        "valid": true
+      }
+    ]
+  },
+  {
+    "description": "validation of JSON-pointer URI fragment strings",
+    "schema": {"format": "json-pointer-uri-fragment"},
+    "tests": [
+      {
+        "description": "a valid JSON-pointer as uri fragment",
+        "data": "#/foo/%25a",
+        "valid": true
+      },
+      {
+        "description": "not a valid JSON-pointer as uri fragment (% not URL-encoded)",
+        "data": "#/foo/%a",
+        "valid": false
+      },
+      {
+        "description": "valid JSON-pointer with empty segment as uri fragment",
+        "data": "#/foo//bar",
+        "valid": true
+      },
+      {
+        "description": "valid JSON-pointer with the last empty segment as uri fragment",
+        "data": "#/foo/bar/",
+        "valid": true
+      }
+    ]
+  },
+  {
+    "description": "validation of relative JSON-pointer strings",
+    "schema": {"format": "relative-json-pointer"},
+    "tests": [
+      {
+        "description": "a valid relative JSON-pointer",
+        "data": "1/foo/bar~0/baz~1/%a",
+        "valid": true
+      },
+      {
+        "description": "a valid relative JSON-pointer with #",
+        "data": "2#",
+        "valid": true
+      },
+      {
+        "description": "parent reference is valid",
+        "data": "1",
+        "valid": true
+      },
+      {
+        "description": "empty string is invalid",
+        "data": "",
+        "valid": false
+      },
+      {
+        "description": "not a valid relative JSON-pointer (~ not escaped)",
+        "data": "1/foo/bar~",
+        "valid": false
+      },
+      {
+        "description": "not a valid relative JSON-pointer (leading 0)",
+        "data": "01/foo",
+        "valid": false
+      },
+      {
+        "description": "not a valid relative JSON-pointer with # (leading 0)",
+        "data": "02#",
+        "valid": false
+      },
+      {
+        "description": "valid relative JSON-pointer with empty segment",
+        "data": "1/foo//bar",
+        "valid": true
+      },
+      {
+        "description": "valid relative JSON-pointer with the last empty segment",
+        "data": "1/foo/bar/",
+        "valid": true
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/rules/if.json
+++ b/test/ajv-spec/tests/rules/if.json
@@ -1,0 +1,134 @@
+[
+  {
+    "description": "if/then keyword validation",
+    "schema": {
+      "if": { "minimum": 10 },
+      "then": { "multipleOf": 2 }
+    },
+    "tests": [
+      {
+        "description": ">= 10 and even is valid",
+        "data": 12,
+        "valid": true
+      },
+      {
+        "description": ">= 10 and odd is invalid",
+        "data": 11,
+        "valid": false
+      },
+      {
+        "description": "< 10 is valid",
+        "data": 9,
+        "valid": true
+      }
+    ]
+  },
+  {
+    "description": "if/then/else keyword validation",
+    "schema": {
+      "if": { "maximum": 10 },
+      "then": { "multipleOf": 2 },
+      "else": { "multipleOf": 5 }
+    },
+    "tests": [
+      {
+        "description": "<=10 and even is valid",
+        "data": 8,
+        "valid": true
+      },
+      {
+        "description": "<=10 and odd is invalid",
+        "data": 7,
+        "valid": false
+      },
+      {
+        "description": ">10 and mulitple of 5 is valid",
+        "data": 15,
+        "valid": true
+      },
+      {
+        "description": ">10 and not mulitple of 5 is invalid",
+        "data": 17,
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "if keyword with id in sibling subschema",
+    "schema": {
+      "$id": "http://example.com/base_if",
+      "if": {
+        "$id": "http://example.com/if",
+        "minimum": 10
+      },
+      "then": { "$ref": "#/definitions/def" },
+      "definitions": {
+        "def": { "multipleOf": 2 }
+      }
+    },
+    "tests": [
+      {
+        "description": ">= 10 and even is valid",
+        "data": 12,
+        "valid": true
+      },
+      {
+        "description": ">= 10 and odd is invalid",
+        "data": 11,
+        "valid": false
+      },
+      {
+        "description": "< 10 is valid",
+        "data": 9,
+        "valid": true
+      }
+    ]
+  },
+  {
+    "description": "then/else without if should be ignored",
+    "schema": {
+      "then": { "multipleOf": 2 },
+      "else": { "multipleOf": 5 }      
+    },
+    "tests": [
+      {
+        "description": "even is valid",
+        "data": 8,
+        "valid": true
+      },
+      {
+        "description": "odd is valid",
+        "data": 7,
+        "valid": true
+      },
+      {
+        "description": "mulitple of 5 is valid",
+        "data": 15,
+        "valid": true
+      },
+      {
+        "description": "not mulitple of 5 is valid",
+        "data": 17,
+        "valid": true
+      }
+    ]
+  },
+  {
+    "description": "if without then/else should be ignored",
+    "schema": {
+      "if": { "maximum": 10 }
+    },
+    "tests": [
+      {
+        "description": "<=10 is valid",
+        "data": 8,
+        "valid": true
+      },
+      {
+        "description": ">10 is valid",
+        "data": 15,
+        "valid": true
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/rules/items.json
+++ b/test/ajv-spec/tests/rules/items.json
@@ -1,0 +1,140 @@
+[
+  {
+    "description": "items with empty schema",
+    "schema": {
+      "items": [{}],
+      "additionalItems": { "type": "string" }
+    },
+    "tests": [
+      {
+        "description": "array with second string is valid",
+        "data": [1, "a"],
+        "valid": true
+      },
+      {
+        "description": "array with second number is invalid",
+        "data": [1, 2],
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "items with subitems",
+    "schema": {
+      "definitions": {
+        "child": {
+          "type": "array",
+          "additionalItems": false,
+          "items": [
+            { "$ref": "#/definitions/sub-child" },
+            { "$ref": "#/definitions/sub-child" }
+          ]
+        },
+        "sub-child": {
+          "type": "object",
+          "properties": { "foo": {} },
+          "required": ["foo"],
+          "additionalProperties": false
+        }
+      },
+      "type": "array",
+      "additionalItems": false,
+      "items": [
+        { "$ref": "#/definitions/child" },
+        { "$ref": "#/definitions/child" },
+        { "$ref": "#/definitions/child" }
+      ]
+    },
+    "tests": [
+      {
+        "description": "valid items",
+        "data": [
+          [ {"foo": null}, {"foo": null} ],
+          [ {"foo": null}, {"foo": null} ],
+          [ {"foo": null}, {"foo": null} ]
+        ],
+        "valid": true
+      },
+      {
+        "description": "too many children",
+        "data": [
+          [ {"foo": null}, {"foo": null} ],
+          [ {"foo": null}, {"foo": null} ],
+          [ {"foo": null}, {"foo": null} ],
+          [ {"foo": null}, {"foo": null} ]
+        ],
+        "valid": false
+      },
+      {
+        "description": "too many sub-children",
+        "data": [
+          [ {"foo": null}, {"foo": null}, {"foo": null} ],
+          [ {"foo": null}, {"foo": null} ],
+          [ {"foo": null}, {"foo": null} ]
+        ],
+        "valid": false
+      },
+      {
+        "description": "wrong child",
+        "data": [
+          {"foo": null},
+          [ {"foo": null}, {"foo": null} ],
+          [ {"foo": null}, {"foo": null} ]
+        ],
+        "valid": false
+      },
+      {
+        "description": "wrong sub-child",
+        "data": [
+          [ {"bar": null}, {"foo": null} ],
+          [ {"foo": null}, {"foo": null} ],
+          [ {"foo": null}, {"foo": null} ]
+        ],
+        "valid": false
+      },
+      {
+        "description": "fewer children is valid",
+        "data": [
+          [ {"foo": null} ],
+          [ {"foo": null} ]
+        ],
+        "valid": true
+      }
+    ]
+  },
+  {
+    "description": "deeply nested items",
+    "schema": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "valid nested array",
+        "data": [[[[1]], [[2],[3]]], [[[4], [5], [6]]]],
+        "valid": true
+      },
+      {
+        "description": "nested array with invalid type",
+        "data": [[[["1"]], [[2],[3]]], [[[4], [5], [6]]]],
+        "valid": false
+      },
+      {
+        "description": "not deep enough",
+        "data": [[[1], [2],[3]], [[4], [5], [6]]],
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/rules/oneOf.json
+++ b/test/ajv-spec/tests/rules/oneOf.json
@@ -1,0 +1,92 @@
+[
+  {
+    "description": "oneOf with one of schemas empty",
+    "schema": {
+      "oneOf": [
+        { "type": "number" },
+        {}
+      ]
+    },
+    "tests": [
+      {
+        "description": "string is valid",
+        "data": "foo",
+        "valid": true
+      },
+      {
+        "description": "number is invalid",
+        "data": 123,
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "oneOf with required",
+    "schema": {
+      "type": "object",
+      "oneOf": [
+        { "required": ["foo", "bar"] },
+        { "required": ["foo", "baz"] }
+      ]
+    },
+    "tests": [
+      {
+        "description": "object with foo and bar is valid",
+        "data": {"foo": 1, "bar": 2},
+        "valid": true
+      },
+      {
+        "description": "object with foo and baz is valid",
+        "data": {"foo": 1, "baz": 3},
+        "valid": true
+      },
+      {
+        "description": "object with foo, bar and baz is invalid",
+        "data": {"foo": 1, "bar": 2, "baz" : 3},
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "oneOf with required with 20+ properties",
+    "schema": {
+      "type": "object",
+      "oneOf": [
+        { "required": ["foo", "bar"] },
+        {
+          "required": [
+            "a", "b", "c", "d", "e", "f", "g", "h", "i", "j",
+            "k", "l", "m", "n", "o", "p", "q", "r", "s", "t",
+            "u", "v", "w", "x", "y", "z"
+          ]
+        }
+      ]
+    },
+    "tests": [
+      {
+        "description": "object with foo and bar is valid",
+        "data": {"foo": 1, "bar": 2},
+        "valid": true
+      },
+      {
+        "description": "object with a, b, c, ... properties is valid",
+        "data": {
+          "a": 0, "b": 0, "c": 0, "d": 0, "e": 0, "f": 0, "g": 0, "h": 0, "i": 0, "j": 0,
+          "k": 0, "l": 0, "m": 0, "n": 0, "o": 0, "p": 0, "q": 0, "r": 0, "s": 0, "t": 0,
+          "u": 0, "v": 0, "w": 0, "x": 0, "y": 0, "z": 0
+        },
+        "valid": true
+      },
+      {
+        "description": "object with foo, bar and a, b, c ... is invalid",
+        "data": {
+          "a": 0, "b": 0, "c": 0, "d": 0, "e": 0, "f": 0, "g": 0, "h": 0, "i": 0, "j": 0,
+          "k": 0, "l": 0, "m": 0, "n": 0, "o": 0, "p": 0, "q": 0, "r": 0, "s": 0, "t": 0,
+          "u": 0, "v": 0, "w": 0, "x": 0, "y": 0, "z": 0,
+          "foo": 1, "bar": 2
+        },
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/rules/required.json
+++ b/test/ajv-spec/tests/rules/required.json
@@ -1,0 +1,25 @@
+[
+  {
+    "description": "required keyword with empty array",
+    "schema": {
+      "required": []
+    },
+    "tests": [
+      {
+        "description": "object with property is valid",
+        "data": { "foo": 1 },
+        "valid": true
+      },
+      {
+        "description": "empty object is valid",
+        "data": {},
+        "valid": true
+      },
+      {
+        "description": "non-object is valid",
+        "data": 1,
+        "valid": true
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/rules/type.json
+++ b/test/ajv-spec/tests/rules/type.json
@@ -1,0 +1,86 @@
+[
+  {
+    "description": "type as array with one item",
+    "schema": {
+      "type": ["string"]
+    },
+    "tests": [
+      {
+        "description": "string is valid",
+        "data": "foo",
+        "valid": true
+      },
+      {
+        "description": "number is invalid",
+        "data": 123,
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "type: array or object",
+    "schema": {
+      "type": ["array", "object"]
+    },
+    "tests": [
+      {
+        "description": "array is valid",
+        "data": [1,2,3],
+        "valid": true
+      },
+      {
+        "description": "object is valid",
+        "data": {"foo":123},
+        "valid": true
+      },
+      {
+        "description": "number is invalid",
+        "data": 123,
+        "valid": false
+      },
+      {
+        "description": "string is invalid",
+        "data": "foo",
+        "valid": false
+      },
+      {
+        "description": "null is invalid",
+        "data": null,
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "type: array, object or null",
+    "schema": {
+      "type": ["array", "object", "null"]
+    },
+    "tests": [
+      {
+        "description": "array is valid",
+        "data": [1,2,3],
+        "valid": true
+      },
+      {
+        "description": "object is valid",
+        "data": {"foo":123},
+        "valid": true
+      },
+      {
+        "description": "null is valid",
+        "data": null,
+        "valid": true
+      },
+      {
+        "description": "number is invalid",
+        "data": 123,
+        "valid": false
+      },
+      {
+        "description": "string is invalid",
+        "data": "foo",
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/rules/uniqueItems.json
+++ b/test/ajv-spec/tests/rules/uniqueItems.json
@@ -1,0 +1,113 @@
+[
+  {
+    "description": "uniqueItems with algorithm using hash",
+    "schema": {
+      "items": { "type": "string" },
+      "uniqueItems": true
+    },
+    "tests": [
+      {
+        "description": "array of unique strings is valid",
+        "data": ["foo", "bar", "baz"],
+        "valid": true
+      },
+      {
+        "description": "array of unique items with strings that are properties of hash is valid",
+        "data": ["toString", "foo"],
+        "valid": true
+      },
+      {
+        "description": "array of non-unique strings is invalid",
+        "data": ["foo", "bar", "bar"],
+        "valid": false
+      },
+      {
+        "description": "array with non-strings is invalid",
+        "data": ["1", 2],
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "uniqueItems with multiple types when the list of types includes array",
+    "schema": {
+      "items": { "type": ["array", "string"] },
+      "uniqueItems": true
+    },
+    "tests": [
+      {
+        "description": "array of unique items is valid",
+        "data": [[1], [2], "foo"],
+        "valid": true
+      },
+      {
+        "description": "array of non-unique items is invalid",
+        "data": [[1], [1], "foo"],
+        "valid": false
+      },
+      {
+        "description": "array with incorrect type is invalid",
+        "data": [{}, 1, 2],
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "uniqueItems with multiple types when the list of types includes object",
+    "schema": {
+      "items": { "type": ["object", "string"] },
+      "uniqueItems": true
+    },
+    "tests": [
+      {
+        "description": "array of unique items is valid",
+        "data": [{"a": 1}, {"b": 2}, "foo"],
+        "valid": true
+      },
+      {
+        "description": "array of non-unique items is invalid",
+        "data": [{"a": 1}, {"a": 1}, "foo"],
+        "valid": false
+      },
+      {
+        "description": "array with incorrect type is invalid",
+        "data": [[], 1, 2],
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "uniqueItems with multiple types when all types are scalar",
+    "schema": {
+      "items": { "type": ["number", "string", "boolean", "null"] },
+      "uniqueItems": true
+    },
+    "tests": [
+      {
+        "description": "array of unique items is valid (string/number)",
+        "data": ["1", 1, 2],
+        "valid": true
+      },
+      {
+        "description": "array of unique items is valid (string/boolean)",
+        "data": ["true", true, false],
+        "valid": true
+      },
+      {
+        "description": "array of unique items is valid (string/null)",
+        "data": ["null", null, 0],
+        "valid": true
+      },
+      {
+        "description": "array of non-unique items is invalid",
+        "data": [1, 1, 2],
+        "valid": false
+      },
+      {
+        "description": "array with incorrect type is invalid",
+        "data": [[], 1, 2],
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/schemas/advanced.json
+++ b/test/ajv-spec/tests/schemas/advanced.json
@@ -1,0 +1,244 @@
+[
+    {
+        "description": "advanced schema from z-schema benchmark (https://github.com/zaggino/z-schema)",
+        "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "/": { "$ref": "#/definitions/entry" }
+            },
+            "patternProperties": {
+                "^(/[^/]+)+$": { "$ref": "#/definitions/entry" }
+            },
+            "additionalProperties": false,
+            "required": [ "/" ],
+            "definitions": {
+                "entry": {
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "description": "schema for an fstab entry",
+                    "type": "object",
+                    "required": [ "storage" ],
+                    "properties": {
+                        "storage": {
+                            "type": "object",
+                            "oneOf": [
+                                { "$ref": "#/definitions/entry/definitions/diskDevice" },
+                                { "$ref": "#/definitions/entry/definitions/diskUUID" },
+                                { "$ref": "#/definitions/entry/definitions/nfs" },
+                                { "$ref": "#/definitions/entry/definitions/tmpfs" }
+                            ]
+                        },
+                        "fstype": {
+                            "enum": [ "ext3", "ext4", "btrfs" ]
+                        },
+                        "options": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": { "type": "string" },
+                            "uniqueItems": true
+                        },
+                        "readonly": { "type": "boolean" }
+                    },
+                    "definitions": {
+                        "diskDevice": {
+                            "properties": {
+                                "type": { "enum": [ "disk" ] },
+                                "device": {
+                                    "type": "string",
+                                    "pattern": "^/dev/[^/]+(/[^/]+)*$"
+                                }
+                            },
+                            "required": [ "type", "device" ],
+                            "additionalProperties": false
+                        },
+                        "diskUUID": {
+                            "properties": {
+                                "type": { "enum": [ "disk" ] },
+                                "label": {
+                                    "type": "string",
+                                    "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+                                }
+                            },
+                            "required": [ "type", "label" ],
+                            "additionalProperties": false
+                        },
+                        "nfs": {
+                            "properties": {
+                                "type": { "enum": [ "nfs" ] },
+                                "remotePath": {
+                                    "type": "string",
+                                    "pattern": "^(/[^/]+)+$"
+                                },
+                                "server": {
+                                    "type": "string",
+                                    "anyOf": [
+                                        { "format": "hostname" },
+                                        { "format": "ipv4" },
+                                        { "format": "ipv6" }
+                                    ]
+                                }
+                            },
+                            "required": [ "type", "server", "remotePath" ],
+                            "additionalProperties": false
+                        },
+                        "tmpfs": {
+                            "properties": {
+                                "type": { "enum": [ "tmpfs" ] },
+                                "sizeInMB": {
+                                    "type": "integer",
+                                    "minimum": 16,
+                                    "maximum": 512
+                                }
+                            },
+                            "required": [ "type", "sizeInMB" ],
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid object from z-schema benchmark",
+                "data": {
+                    "/": {
+                        "storage": {
+                            "type": "disk",
+                            "device": "/dev/sda1"
+                        },
+                        "fstype": "btrfs",
+                        "readonly": true
+                    },
+                    "/var": {
+                        "storage": {
+                            "type": "disk",
+                            "label": "8f3ba6f4-5c70-46ec-83af-0d5434953e5f"
+                        },
+                        "fstype": "ext4",
+                        "options": [ "nosuid" ]
+                    },
+                    "/tmp": {
+                        "storage": {
+                            "type": "tmpfs",
+                            "sizeInMB": 64
+                        }
+                    },
+                    "/var/www": {
+                        "storage": {
+                            "type": "nfs",
+                            "server": "my.nfs.server",
+                            "remotePath": "/exports/mypath"
+                        }
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "not object",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "root only is valid",
+                "data": {
+                    "/": {
+                        "storage": {
+                            "type": "disk",
+                            "device": "/dev/sda1"
+                        },
+                        "fstype": "btrfs",
+                        "readonly": true
+                    }
+                },
+                "valid": true
+            },
+            {
+                "description": "missing root entry",
+                "data": {
+                    "no root/": {
+                        "storage": {
+                            "type": "disk",
+                            "device": "/dev/sda1"
+                        },
+                        "fstype": "btrfs",
+                        "readonly": true
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "invalid entry key",
+                "data": {
+                    "/": {
+                        "storage": {
+                            "type": "disk",
+                            "device": "/dev/sda1"
+                        },
+                        "fstype": "btrfs",
+                        "readonly": true
+                    },
+                    "invalid/var": {
+                        "storage": {
+                            "type": "disk",
+                            "label": "8f3ba6f4-5c70-46ec-83af-0d5434953e5f"
+                        },
+                        "fstype": "ext4",
+                        "options": [ "nosuid" ]
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "missing storage in entry",
+                "data": {
+                    "/": {
+                        "fstype": "btrfs",
+                        "readonly": true
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "missing storage type",
+                "data": {
+                    "/": {
+                        "storage": {
+                            "device": "/dev/sda1"
+                        },
+                        "fstype": "btrfs",
+                        "readonly": true
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "storage type should be a string",
+                "data": {
+                    "/": {
+                        "storage": {
+                            "type": null,
+                            "device": "/dev/sda1"
+                        },
+                        "fstype": "btrfs",
+                        "readonly": true
+                    }
+                },
+                "valid": false
+            },
+            {
+                "description": "storage device should match pattern",
+                "data": {
+                    "/": {
+                        "storage": {
+                            "type": null,
+                            "device": "invalid/dev/sda1"
+                        },
+                        "fstype": "btrfs",
+                        "readonly": true
+                    }
+                },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/test/ajv-spec/tests/schemas/basic.json
+++ b/test/ajv-spec/tests/schemas/basic.json
@@ -1,0 +1,135 @@
+[
+    {
+        "description": "basic schema from z-schema benchmark (https://github.com/zaggino/z-schema)",
+        "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "Product set",
+            "type": "array",
+            "items": {
+                "title": "Product",
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "description": "The unique identifier for a product",
+                        "type": "number"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "price": {
+                        "type": "number",
+                        "exclusiveMinimum": 0
+                    },
+                    "tags": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "minItems": 1,
+                        "uniqueItems": true
+                    },
+                    "dimensions": {
+                        "type": "object",
+                        "properties": {
+                            "length": {"type": "number"},
+                            "width": {"type": "number"},
+                            "height": {"type": "number"}
+                        },
+                        "required": ["length", "width", "height"]
+                    },
+                    "warehouseLocation": {
+                        "description": "Coordinates of the warehouse with the product"
+                    }
+                },
+                "required": ["id", "name", "price"]
+            }
+        },
+        "tests": [
+            {
+                "description": "valid array from z-schema benchmark",
+                "data": [
+                    {
+                        "id": 2,
+                        "name": "An ice sculpture",
+                        "price": 12.50,
+                        "tags": ["cold", "ice"],
+                        "dimensions": {
+                            "length": 7.0,
+                            "width": 12.0,
+                            "height": 9.5
+                        },
+                        "warehouseLocation": {
+                            "latitude": -78.75,
+                            "longitude": 20.4
+                        }
+                    },
+                    {
+                        "id": 3,
+                        "name": "A blue mouse",
+                        "price": 25.50,
+                        "dimensions": {
+                            "length": 3.1,
+                            "width": 1.0,
+                            "height": 1.0
+                        },
+                        "warehouseLocation": {
+                            "latitude": 54.4,
+                            "longitude": -32.7
+                        }
+                    }
+                ],
+                "valid": true
+            },
+            {
+                "description": "not array",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "array of not onjects",
+                "data": [1,2,3],
+                "valid": false
+            },
+            {
+                "description": "missing required properties",
+                "data": [{}],
+                "valid": false
+            },
+            {
+                "description": "required property of wrong type",
+                "data": [{"id": 1, "name": "product", "price": "not valid"}],
+                "valid": false
+            },
+            {
+                "description": "smallest valid product",
+                "data": [{"id": 1, "name": "product", "price": 100}],
+                "valid": true
+            },
+            {
+                "description": "tags should be array",
+                "data": [{"tags":{}, "id": 1, "name": "product", "price": 100}],
+                "valid": false
+            },
+            {
+                "description": "dimensions should be object",
+                "data": [{"dimensions":[], "id": 1, "name": "product", "price": 100}],
+                "valid": false
+            },
+            {
+                "description": "valid product with tag",
+                "data": [{"tags":["product"], "id": 1, "name": "product", "price": 100}],
+                "valid": true
+            },
+            {
+                "description": "dimensions miss required properties",
+                "data": [{"dimensions":{}, "tags":["product"], "id": 1, "name": "product", "price": 100}],
+                "valid": false
+            },
+            {
+                "description": "valid product with tag and dimensions",
+                "data": [{"dimensions":{"length": 7,"width": 12,"height": 9.5}, "tags":["product"], "id": 1, "name": "product", "price": 100}],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/test/ajv-spec/tests/schemas/complex.json
+++ b/test/ajv-spec/tests/schemas/complex.json
@@ -1,0 +1,378 @@
+[
+  {
+    "description": "complex schema from jsck benchmark (https://github.com/pandastrike/jsck)",
+    "schema": {
+      "type": "array",
+      "items": { "$ref": "#transaction" },
+      "minItems": 1,
+      "definitions": {
+        "base58": {
+          "$id": "#base58",
+          "type": "string",
+          "pattern": "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+$"
+        },
+        "hex": {
+          "$id": "#hex",
+          "type": "string",
+          "pattern": "^[0123456789A-Fa-f]+$"
+        },
+        "tx_id": {
+          "$id": "#tx_id",
+          "allOf": [
+            { "$ref": "#hex" },
+            {
+              "minLength": 64,
+              "maxLength": 64
+            }
+          ]
+        },
+        "address": {
+          "$id": "#address",
+          "allOf": [
+            { "$ref": "#base58" },
+            {
+              "minLength": 34,
+              "maxLength": 34
+            }
+          ]
+        },
+        "signature": {
+          "$id": "#signature",
+          "allOf": [
+            { "$ref": "#hex" },
+            {
+              "minLength": 128,
+              "maxLength": 128
+            }
+          ]
+        },
+        "transaction": {
+          "$id": "#transaction",
+          "additionalProperties": false,
+          "required": [
+            "metadata",
+            "hash",
+            "inputs",
+            "outputs"
+          ],
+          "properties": {
+            "metadata": {
+              "type": "object",
+              "required": [
+                "amount",
+                "fee"
+              ],
+              "properties": {
+                "amount": {
+                  "type": "integer"
+                },
+                "fee": {
+                  "type": "integer",
+                  "multipleOf": 10000
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "unsigned",
+                    "unconfirmed",
+                    "confirmed",
+                    "invalid"
+                  ]
+                },
+                "confirmations": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "block_time": {
+                  "type": "integer"
+                }
+              }
+            },
+            "version": {
+              "type": "integer"
+            },
+            "lock_time": {
+              "type": "integer"
+            },
+            "hash": { "$ref": "#tx_id" },
+            "inputs": {
+              "type": "array",
+              "items": { "$ref": "#input" },
+              "minItems": 1
+            },
+            "outputs": {
+              "type": "array",
+              "items": { "$ref": "#output" },
+              "minItems": 1
+            }
+          }
+        },
+        "input": {
+          "$id": "#input",
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "index",
+            "output",
+            "script_sig"
+          ],
+          "properties": {
+            "index": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "output": { "$ref": "#output" },
+            "sig_hash": { "$ref": "#hex" },
+            "script_sig": { "$ref": "#hex" },
+            "signatures": {
+              "type": "object",
+              "description": "A dictionary of signatures.  Keys represent keypair names",
+              "minProperties": 1,
+              "maxProperties": 3,
+              "additionalProperties": { "$ref": "#signature" }
+            }
+          }
+        },
+        "output": {
+          "$id": "#output",
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "hash",
+            "index",
+            "value",
+            "script"
+          ],
+          "properties": {
+            "hash": { "$ref": "#tx_id" },
+            "index": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "value": {
+              "type": "integer"
+            },
+            "script": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "standard",
+                    "p2sh"
+                  ]
+                },
+                "asm": {
+                  "type": "string"
+                }
+              }
+            },
+            "address": { "$ref": "#address" },
+            "metadata": {
+              "type": "object",
+              "dependencies": {
+                "wallet_path": [
+                  "public_seeds"
+                ]
+              },
+              "properties": {
+                "wallet_path": {
+                  "type": "string"
+                },
+                "public_seeds": {
+                  "type": "object",
+                  "minProperties": 1,
+                  "maxProperties": 3,
+                  "additionalProperties": {
+                    "anyOf": [
+                      { "$ref": "#base58" },
+                      { "$ref": "#hex" }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "valid array from jsck benchmark",
+        "data": [
+          {
+            "metadata": {
+              "amount": 38043749285,
+              "fee": 20000,
+              "status": "confirmed",
+              "confirmations": 73,
+              "block_time": 1415993584376
+            },
+            "version": 1,
+            "lock_time": 0,
+            "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+            "inputs": [
+              {
+                "index": 0,
+                "script_sig": "3046022100be69797cf5d784412b1258256eb657c191a04893479dfa2ae5c7f2088c7adbe0022100e6b000bd633b286ed1b9bc7682fe753d9fdad61fbe5da2a6e9444198e33a670f01",
+                "signatures": {
+                  "primary": "3046022100be69797cf5d784412b1258256eb657c191a04893479dfa2ae5c7f2088c7adbe0022100e6b000bd633b286ed1b9bc7682fe753d9fdad61fbe5da2a7",
+                  "cosigner": "a2ad5ebf16dadf9d357ef2867cb9b1de682b336db000b6e0012200ebda7c8802f7c5ea2afd97439840a191c756be6528521b214487d5fc79796eb00122064037"
+                },
+                "output": {
+                  "hash": "6b040cd7a4676b5c7b11f144e73c1958c177fcd79e934f6be8ce02c8cd12546d",
+                  "index": 1,
+                  "value": 38043749285,
+                  "script": {
+                    "type": "standard",
+                    "asm": "OP_DUP OP_HASH160 7d4e6d55e1dffb0df85f509343451d170d147551 OP_EQUALVERIFY OP_CHECKSIG"
+                  }
+                }
+              }
+            ],
+            "outputs": [
+              {
+                "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+                "index": 0,
+                "value": 38042249285,
+                "script": {
+                  "type": "standard",
+                  "asm": "OP_DUP OP_HASH160 7d4e6d55e1dffb0df85f509343451d170d147551 OP_EQUALVERIFY OP_CHECKSIG"
+                },
+                "address": "1CRZRBwfuwUaVSPJtd6DBuezbm7XPBHLa1",
+                "metadata": {
+                  "type": "change",
+                  "wallet_path": "m/44/0/1/356",
+                  "public_seeds": {
+                    "primary": "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8",
+                    "cosigner": "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8"
+                  }
+                }
+              },
+              {
+                "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+                "index": 1,
+                "value": 1500000,
+                "script": {
+                  "type": "standard",
+                  "asm": "OP_DUP OP_HASH160 3bc576e6960a9d45201ba5087e39224d0a05a079 OP_EQUALVERIFY OP_CHECKSIG"
+                },
+                "address": "16T3RPZLmxtXQCgWi1S8kef5Ca6jqXhoeT"
+              }
+            ]
+          },
+          {
+            "metadata": {
+              "amount": 38043749285,
+              "fee": 20000,
+              "status": "unconfirmed",
+              "confirmations": 73,
+              "block_time": 1415993584376
+            },
+            "version": 1,
+            "lock_time": 0,
+            "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+            "inputs": [
+              {
+                "index": 0,
+                "script_sig": "3046022100be69797cf5d784412b1258256eb657c191a04893479dfa2ae5c7f2088c7adbe0022100e6b000bd633b286ed1b9bc7682fe753d9fdad61fbe5da2a6e9444198e33a670f01",
+                "output": {
+                  "hash": "6b040cd7a4676b5c7b11f144e73c1958c177fcd79e934f6be8ce02c8cd12546d",
+                  "index": 1,
+                  "value": 38043749285,
+                  "script": {
+                    "type": "standard",
+                    "asm": "OP_DUP OP_HASH160 7d4e6d55e1dffb0df85f509343451d170d147551 OP_EQUALVERIFY OP_CHECKSIG"
+                  }
+                }
+              }
+            ],
+            "outputs": [
+              {
+                "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+                "index": 0,
+                "value": 38042249285,
+                "script": {
+                  "type": "standard",
+                  "asm": "OP_DUP OP_HASH160 7d4e6d55e1dffb0df85f509343451d170d147551 OP_EQUALVERIFY OP_CHECKSIG"
+                },
+                "address": "1CRZRBwfuwUaVSPJtd6DBuezbm7XPBHLa1",
+                "metadata": {
+                  "type": "change"
+                }
+              },
+              {
+                "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+                "index": 1,
+                "value": 1500000,
+                "script": {
+                  "type": "standard",
+                  "asm": "OP_DUP OP_HASH160 3bc576e6960a9d45201ba5087e39224d0a05a079 OP_EQUALVERIFY OP_CHECKSIG"
+                },
+                "address": "16T3RPZLmxtXQCgWi1S8kef5Ca6jqXhoeT"
+              }
+            ]
+          },
+          {
+            "metadata": {
+              "amount": 38043749285,
+              "fee": 20000,
+              "status": "unconfirmed",
+              "confirmations": 73,
+              "block_time": 1415993584376
+            },
+            "version": 1,
+            "lock_time": 0,
+            "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+            "inputs": [
+              {
+                "index": 0,
+                "script_sig": "3046022100be69797cf5d784412b1258256eb657c191a04893479dfa2ae5c7f2088c7adbe0022100e6b000bd633b286ed1b9bc7682fe753d9fdad61fbe5da2a6e9444198e33a670f01",
+                "output": {
+                  "hash": "6b040cd7a4676b5c7b11f144e73c1958c177fcd79e934f6be8ce02c8cd12546d",
+                  "index": 1,
+                  "value": 38043749285,
+                  "script": {
+                    "type": "standard",
+                    "asm": "OP_DUP OP_HASH160 7d4e6d55e1dffb0df85f509343451d170d147551 OP_EQUALVERIFY OP_CHECKSIG"
+                  }
+                }
+              }
+            ],
+            "outputs": [
+              {
+                "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+                "index": 0,
+                "value": 38042249285,
+                "script": {
+                  "type": "standard",
+                  "asm": "OP_DUP OP_HASH160 7d4e6d55e1dffb0df85f509343451d170d147551 OP_EQUALVERIFY OP_CHECKSIG"
+                },
+                "address": "1CRZRBwfuwUaVSPJtd6DBuezbm7XPBHLa1",
+                "metadata": {
+                  "type": "change"
+                }
+              },
+              {
+                "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+                "index": 1,
+                "value": 1500000,
+                "script": {
+                  "type": "standard",
+                  "asm": "OP_DUP OP_HASH160 3bc576e6960a9d45201ba5087e39224d0a05a079 OP_EQUALVERIFY OP_CHECKSIG"
+                },
+                "address": "16T3RPZLmxtXQCgWi1S8kef5Ca6jqXhoeT"
+              }
+            ]
+          }
+        ],
+        "valid": true
+      },
+      {
+        "description": "not array",
+        "data": 1,
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/schemas/complex2.json
+++ b/test/ajv-spec/tests/schemas/complex2.json
@@ -1,0 +1,486 @@
+[
+  {
+    "description": "complex schema from jsck benchmark without IDs in definitions",
+    "schema": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/transaction" },
+      "minItems": 1,
+      "definitions": {
+        "base58": {
+          "type": "string",
+          "pattern": "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+$"
+        },
+        "hex": {
+          "type": "string",
+          "pattern": "^[0123456789A-Fa-f]+$"
+        },
+        "tx_id": {
+          "allOf": [
+            { "$ref": "#/definitions/hex" },
+            {
+              "minLength": 64,
+              "maxLength": 64
+            }
+          ]
+        },
+        "address": {
+          "allOf": [
+            { "$ref": "#/definitions/base58" },
+            {
+              "minLength": 34,
+              "maxLength": 34
+            }
+          ]
+        },
+        "signature": {
+          "allOf": [
+            { "$ref": "#/definitions/hex" },
+            {
+              "minLength": 128,
+              "maxLength": 128
+            }
+          ]
+        },
+        "transaction": {
+          "additionalProperties": false,
+          "required": [
+            "metadata",
+            "hash",
+            "inputs",
+            "outputs"
+          ],
+          "properties": {
+            "metadata": {
+              "type": "object",
+              "required": [
+                "amount",
+                "fee"
+              ],
+              "properties": {
+                "amount": {
+                  "type": "integer"
+                },
+                "fee": {
+                  "type": "integer",
+                  "multipleOf": 10000
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "unsigned",
+                    "unconfirmed",
+                    "confirmed",
+                    "invalid"
+                  ]
+                },
+                "confirmations": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "block_time": {
+                  "type": "integer"
+                }
+              }
+            },
+            "version": {
+              "type": "integer"
+            },
+            "lock_time": {
+              "type": "integer"
+            },
+            "hash": { "$ref": "#/definitions/tx_id" },
+            "inputs": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/input" },
+              "minItems": 1
+            },
+            "outputs": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/output" },
+              "minItems": 1
+            }
+          }
+        },
+        "input": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "index",
+            "output",
+            "script_sig"
+          ],
+          "properties": {
+            "index": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "output": { "$ref": "#/definitions/output" },
+            "sig_hash": { "$ref": "#/definitions/hex" },
+            "script_sig": { "$ref": "#/definitions/hex" },
+            "signatures": {
+              "type": "object",
+              "description": "A dictionary of signatures.  Keys represent keypair names",
+              "minProperties": 1,
+              "maxProperties": 3,
+              "additionalProperties": { "$ref": "#/definitions/signature" }
+            }
+          }
+        },
+        "output": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "hash",
+            "index",
+            "value",
+            "script"
+          ],
+          "properties": {
+            "hash": { "$ref": "#/definitions/tx_id" },
+            "index": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "value": {
+              "type": "integer"
+            },
+            "script": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "standard",
+                    "p2sh"
+                  ]
+                },
+                "asm": {
+                  "type": "string"
+                }
+              }
+            },
+            "address": { "$ref": "#/definitions/address" },
+            "metadata": {
+              "type": "object",
+              "dependencies": {
+                "wallet_path": [
+                  "public_seeds"
+                ]
+              },
+              "properties": {
+                "wallet_path": {
+                  "type": "string"
+                },
+                "public_seeds": {
+                  "type": "object",
+                  "minProperties": 1,
+                  "maxProperties": 3,
+                  "additionalProperties": {
+                    "anyOf": [
+                      { "$ref": "#/definitions/base58" },
+                      { "$ref": "#/definitions/hex" }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "valid array from jsck benchmark",
+        "data": [
+          {
+            "metadata": {
+              "amount": 38043749285,
+              "fee": 20000,
+              "status": "confirmed",
+              "confirmations": 73,
+              "block_time": 1415993584376
+            },
+            "version": 1,
+            "lock_time": 0,
+            "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+            "inputs": [
+              {
+                "index": 0,
+                "script_sig": "3046022100be69797cf5d784412b1258256eb657c191a04893479dfa2ae5c7f2088c7adbe0022100e6b000bd633b286ed1b9bc7682fe753d9fdad61fbe5da2a6e9444198e33a670f01",
+                "signatures": {
+                  "primary": "3046022100be69797cf5d784412b1258256eb657c191a04893479dfa2ae5c7f2088c7adbe0022100e6b000bd633b286ed1b9bc7682fe753d9fdad61fbe5da2a7",
+                  "cosigner": "a2ad5ebf16dadf9d357ef2867cb9b1de682b336db000b6e0012200ebda7c8802f7c5ea2afd97439840a191c756be6528521b214487d5fc79796eb00122064037"
+                },
+                "output": {
+                  "hash": "6b040cd7a4676b5c7b11f144e73c1958c177fcd79e934f6be8ce02c8cd12546d",
+                  "index": 1,
+                  "value": 38043749285,
+                  "script": {
+                    "type": "standard",
+                    "asm": "OP_DUP OP_HASH160 7d4e6d55e1dffb0df85f509343451d170d147551 OP_EQUALVERIFY OP_CHECKSIG"
+                  }
+                }
+              }
+            ],
+            "outputs": [
+              {
+                "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+                "index": 0,
+                "value": 38042249285,
+                "script": {
+                  "type": "standard",
+                  "asm": "OP_DUP OP_HASH160 7d4e6d55e1dffb0df85f509343451d170d147551 OP_EQUALVERIFY OP_CHECKSIG"
+                },
+                "address": "1CRZRBwfuwUaVSPJtd6DBuezbm7XPBHLa1",
+                "metadata": {
+                  "type": "change",
+                  "wallet_path": "m/44/0/1/356",
+                  "public_seeds": {
+                    "primary": "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8",
+                    "cosigner": "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8"
+                  }
+                }
+              },
+              {
+                "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+                "index": 1,
+                "value": 1500000,
+                "script": {
+                  "type": "standard",
+                  "asm": "OP_DUP OP_HASH160 3bc576e6960a9d45201ba5087e39224d0a05a079 OP_EQUALVERIFY OP_CHECKSIG"
+                },
+                "address": "16T3RPZLmxtXQCgWi1S8kef5Ca6jqXhoeT"
+              }
+            ]
+          },
+          {
+            "metadata": {
+              "amount": 38043749285,
+              "fee": 20000,
+              "status": "unconfirmed",
+              "confirmations": 73,
+              "block_time": 1415993584376
+            },
+            "version": 1,
+            "lock_time": 0,
+            "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+            "inputs": [
+              {
+                "index": 0,
+                "script_sig": "3046022100be69797cf5d784412b1258256eb657c191a04893479dfa2ae5c7f2088c7adbe0022100e6b000bd633b286ed1b9bc7682fe753d9fdad61fbe5da2a6e9444198e33a670f01",
+                "output": {
+                  "hash": "6b040cd7a4676b5c7b11f144e73c1958c177fcd79e934f6be8ce02c8cd12546d",
+                  "index": 1,
+                  "value": 38043749285,
+                  "script": {
+                    "type": "standard",
+                    "asm": "OP_DUP OP_HASH160 7d4e6d55e1dffb0df85f509343451d170d147551 OP_EQUALVERIFY OP_CHECKSIG"
+                  }
+                }
+              }
+            ],
+            "outputs": [
+              {
+                "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+                "index": 0,
+                "value": 38042249285,
+                "script": {
+                  "type": "standard",
+                  "asm": "OP_DUP OP_HASH160 7d4e6d55e1dffb0df85f509343451d170d147551 OP_EQUALVERIFY OP_CHECKSIG"
+                },
+                "address": "1CRZRBwfuwUaVSPJtd6DBuezbm7XPBHLa1",
+                "metadata": {
+                  "type": "change"
+                }
+              },
+              {
+                "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+                "index": 1,
+                "value": 1500000,
+                "script": {
+                  "type": "standard",
+                  "asm": "OP_DUP OP_HASH160 3bc576e6960a9d45201ba5087e39224d0a05a079 OP_EQUALVERIFY OP_CHECKSIG"
+                },
+                "address": "16T3RPZLmxtXQCgWi1S8kef5Ca6jqXhoeT"
+              }
+            ]
+          },
+          {
+            "metadata": {
+              "amount": 38043749285,
+              "fee": 20000,
+              "status": "unconfirmed",
+              "confirmations": 73,
+              "block_time": 1415993584376
+            },
+            "version": 1,
+            "lock_time": 0,
+            "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+            "inputs": [
+              {
+                "index": 0,
+                "script_sig": "3046022100be69797cf5d784412b1258256eb657c191a04893479dfa2ae5c7f2088c7adbe0022100e6b000bd633b286ed1b9bc7682fe753d9fdad61fbe5da2a6e9444198e33a670f01",
+                "output": {
+                  "hash": "6b040cd7a4676b5c7b11f144e73c1958c177fcd79e934f6be8ce02c8cd12546d",
+                  "index": 1,
+                  "value": 38043749285,
+                  "script": {
+                    "type": "standard",
+                    "asm": "OP_DUP OP_HASH160 7d4e6d55e1dffb0df85f509343451d170d147551 OP_EQUALVERIFY OP_CHECKSIG"
+                  }
+                }
+              }
+            ],
+            "outputs": [
+              {
+                "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+                "index": 0,
+                "value": 38042249285,
+                "script": {
+                  "type": "standard",
+                  "asm": "OP_DUP OP_HASH160 7d4e6d55e1dffb0df85f509343451d170d147551 OP_EQUALVERIFY OP_CHECKSIG"
+                },
+                "address": "1CRZRBwfuwUaVSPJtd6DBuezbm7XPBHLa1",
+                "metadata": {
+                  "type": "change"
+                }
+              },
+              {
+                "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+                "index": 1,
+                "value": 1500000,
+                "script": {
+                  "type": "standard",
+                  "asm": "OP_DUP OP_HASH160 3bc576e6960a9d45201ba5087e39224d0a05a079 OP_EQUALVERIFY OP_CHECKSIG"
+                },
+                "address": "16T3RPZLmxtXQCgWi1S8kef5Ca6jqXhoeT"
+              }
+            ]
+          }
+        ],
+        "valid": true
+      },
+      {
+        "description": "not array",
+        "data": 1,
+        "valid": false
+      },
+      {
+        "description": "one valid item",
+        "data": [
+          {
+            "metadata": {
+              "amount": 38043749285,
+              "fee": 20000,
+              "status": "unconfirmed",
+              "confirmations": 73,
+              "block_time": 1415993584376
+            },
+            "version": 1,
+            "lock_time": 0,
+            "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+            "inputs": [
+              {
+                "index": 0,
+                "script_sig": "3046022100be69797cf5d784412b1258256eb657c191a04893479dfa2ae5c7f2088c7adbe0022100e6b000bd633b286ed1b9bc7682fe753d9fdad61fbe5da2a6e9444198e33a670f01",
+                "output": {
+                  "hash": "6b040cd7a4676b5c7b11f144e73c1958c177fcd79e934f6be8ce02c8cd12546d",
+                  "index": 1,
+                  "value": 38043749285,
+                  "script": {
+                    "type": "standard",
+                    "asm": "OP_DUP OP_HASH160 7d4e6d55e1dffb0df85f509343451d170d147551 OP_EQUALVERIFY OP_CHECKSIG"
+                  }
+                }
+              }
+            ],
+            "outputs": [
+              {
+                "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+                "index": 0,
+                "value": 38042249285,
+                "script": {
+                  "type": "standard",
+                  "asm": "OP_DUP OP_HASH160 7d4e6d55e1dffb0df85f509343451d170d147551 OP_EQUALVERIFY OP_CHECKSIG"
+                },
+                "address": "1CRZRBwfuwUaVSPJtd6DBuezbm7XPBHLa1",
+                "metadata": {
+                  "type": "change"
+                }
+              },
+              {
+                "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+                "index": 1,
+                "value": 1500000,
+                "script": {
+                  "type": "standard",
+                  "asm": "OP_DUP OP_HASH160 3bc576e6960a9d45201ba5087e39224d0a05a079 OP_EQUALVERIFY OP_CHECKSIG"
+                },
+                "address": "16T3RPZLmxtXQCgWi1S8kef5Ca6jqXhoeT"
+              }
+            ]
+          }
+        ],
+        "valid": true
+      },
+      {
+        "description": "one invalid item",
+        "data": [
+          {
+            "metadata": {
+              "amount": 38043749285,
+              "fee": 20000,
+              "status": "unconfirmed",
+              "confirmations": 73,
+              "block_time": 1415993584376
+            },
+            "version": 1,
+            "lock_time": 0,
+            "hash": "$_is_invalid",
+            "inputs": [
+              {
+                "index": 0,
+                "script_sig": "3046022100be69797cf5d784412b1258256eb657c191a04893479dfa2ae5c7f2088c7adbe0022100e6b000bd633b286ed1b9bc7682fe753d9fdad61fbe5da2a6e9444198e33a670f01",
+                "output": {
+                  "hash": "6b040cd7a4676b5c7b11f144e73c1958c177fcd79e934f6be8ce02c8cd12546d",
+                  "index": 1,
+                  "value": 38043749285,
+                  "script": {
+                    "type": "standard",
+                    "asm": "OP_DUP OP_HASH160 7d4e6d55e1dffb0df85f509343451d170d147551 OP_EQUALVERIFY OP_CHECKSIG"
+                  }
+                }
+              }
+            ],
+            "outputs": [
+              {
+                "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+                "index": 0,
+                "value": 38042249285,
+                "script": {
+                  "type": "standard",
+                  "asm": "OP_DUP OP_HASH160 7d4e6d55e1dffb0df85f509343451d170d147551 OP_EQUALVERIFY OP_CHECKSIG"
+                },
+                "address": "1CRZRBwfuwUaVSPJtd6DBuezbm7XPBHLa1",
+                "metadata": {
+                  "type": "change"
+                }
+              },
+              {
+                "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+                "index": 1,
+                "value": 1500000,
+                "script": {
+                  "type": "standard",
+                  "asm": "OP_DUP OP_HASH160 3bc576e6960a9d45201ba5087e39224d0a05a079 OP_EQUALVERIFY OP_CHECKSIG"
+                },
+                "address": "16T3RPZLmxtXQCgWi1S8kef5Ca6jqXhoeT"
+              }
+            ]
+          }
+        ],
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/schemas/complex3.json
+++ b/test/ajv-spec/tests/schemas/complex3.json
@@ -1,0 +1,379 @@
+[
+  {
+    "description": "complex schema from jsck benchmark (https://github.com/pandastrike/jsck)",
+    "schema": {
+      "$id": "http://example.com/complex3.json",
+      "type": "array",
+      "items": { "$ref": "#transaction" },
+      "minItems": 1,
+      "definitions": {
+        "base58": {
+          "$id": "#base58",
+          "type": "string",
+          "pattern": "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+$"
+        },
+        "hex": {
+          "$id": "#hex",
+          "type": "string",
+          "pattern": "^[0123456789A-Fa-f]+$"
+        },
+        "tx_id": {
+          "$id": "#tx_id",
+          "allOf": [
+            { "$ref": "#hex" },
+            {
+              "minLength": 64,
+              "maxLength": 64
+            }
+          ]
+        },
+        "address": {
+          "$id": "#address",
+          "allOf": [
+            { "$ref": "#base58" },
+            {
+              "minLength": 34,
+              "maxLength": 34
+            }
+          ]
+        },
+        "signature": {
+          "$id": "#signature",
+          "allOf": [
+            { "$ref": "#hex" },
+            {
+              "minLength": 128,
+              "maxLength": 128
+            }
+          ]
+        },
+        "transaction": {
+          "$id": "#transaction",
+          "additionalProperties": false,
+          "required": [
+            "metadata",
+            "hash",
+            "inputs",
+            "outputs"
+          ],
+          "properties": {
+            "metadata": {
+              "type": "object",
+              "required": [
+                "amount",
+                "fee"
+              ],
+              "properties": {
+                "amount": {
+                  "type": "integer"
+                },
+                "fee": {
+                  "type": "integer",
+                  "multipleOf": 10000
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "unsigned",
+                    "unconfirmed",
+                    "confirmed",
+                    "invalid"
+                  ]
+                },
+                "confirmations": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "block_time": {
+                  "type": "integer"
+                }
+              }
+            },
+            "version": {
+              "type": "integer"
+            },
+            "lock_time": {
+              "type": "integer"
+            },
+            "hash": { "$ref": "#tx_id" },
+            "inputs": {
+              "type": "array",
+              "items": { "$ref": "#input" },
+              "minItems": 1
+            },
+            "outputs": {
+              "type": "array",
+              "items": { "$ref": "#output" },
+              "minItems": 1
+            }
+          }
+        },
+        "input": {
+          "$id": "#input",
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "index",
+            "output",
+            "script_sig"
+          ],
+          "properties": {
+            "index": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "output": { "$ref": "#output" },
+            "sig_hash": { "$ref": "#hex" },
+            "script_sig": { "$ref": "#hex" },
+            "signatures": {
+              "type": "object",
+              "description": "A dictionary of signatures.  Keys represent keypair names",
+              "minProperties": 1,
+              "maxProperties": 3,
+              "additionalProperties": { "$ref": "#signature" }
+            }
+          }
+        },
+        "output": {
+          "$id": "#output",
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "hash",
+            "index",
+            "value",
+            "script"
+          ],
+          "properties": {
+            "hash": { "$ref": "#tx_id" },
+            "index": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "value": {
+              "type": "integer"
+            },
+            "script": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "standard",
+                    "p2sh"
+                  ]
+                },
+                "asm": {
+                  "type": "string"
+                }
+              }
+            },
+            "address": { "$ref": "#address" },
+            "metadata": {
+              "type": "object",
+              "dependencies": {
+                "wallet_path": [
+                  "public_seeds"
+                ]
+              },
+              "properties": {
+                "wallet_path": {
+                  "type": "string"
+                },
+                "public_seeds": {
+                  "type": "object",
+                  "minProperties": 1,
+                  "maxProperties": 3,
+                  "additionalProperties": {
+                    "anyOf": [
+                      { "$ref": "#base58" },
+                      { "$ref": "#hex" }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "valid array from jsck benchmark",
+        "data": [
+          {
+            "metadata": {
+              "amount": 38043749285,
+              "fee": 20000,
+              "status": "confirmed",
+              "confirmations": 73,
+              "block_time": 1415993584376
+            },
+            "version": 1,
+            "lock_time": 0,
+            "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+            "inputs": [
+              {
+                "index": 0,
+                "script_sig": "3046022100be69797cf5d784412b1258256eb657c191a04893479dfa2ae5c7f2088c7adbe0022100e6b000bd633b286ed1b9bc7682fe753d9fdad61fbe5da2a6e9444198e33a670f01",
+                "signatures": {
+                  "primary": "3046022100be69797cf5d784412b1258256eb657c191a04893479dfa2ae5c7f2088c7adbe0022100e6b000bd633b286ed1b9bc7682fe753d9fdad61fbe5da2a7",
+                  "cosigner": "a2ad5ebf16dadf9d357ef2867cb9b1de682b336db000b6e0012200ebda7c8802f7c5ea2afd97439840a191c756be6528521b214487d5fc79796eb00122064037"
+                },
+                "output": {
+                  "hash": "6b040cd7a4676b5c7b11f144e73c1958c177fcd79e934f6be8ce02c8cd12546d",
+                  "index": 1,
+                  "value": 38043749285,
+                  "script": {
+                    "type": "standard",
+                    "asm": "OP_DUP OP_HASH160 7d4e6d55e1dffb0df85f509343451d170d147551 OP_EQUALVERIFY OP_CHECKSIG"
+                  }
+                }
+              }
+            ],
+            "outputs": [
+              {
+                "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+                "index": 0,
+                "value": 38042249285,
+                "script": {
+                  "type": "standard",
+                  "asm": "OP_DUP OP_HASH160 7d4e6d55e1dffb0df85f509343451d170d147551 OP_EQUALVERIFY OP_CHECKSIG"
+                },
+                "address": "1CRZRBwfuwUaVSPJtd6DBuezbm7XPBHLa1",
+                "metadata": {
+                  "type": "change",
+                  "wallet_path": "m/44/0/1/356",
+                  "public_seeds": {
+                    "primary": "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8",
+                    "cosigner": "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8"
+                  }
+                }
+              },
+              {
+                "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+                "index": 1,
+                "value": 1500000,
+                "script": {
+                  "type": "standard",
+                  "asm": "OP_DUP OP_HASH160 3bc576e6960a9d45201ba5087e39224d0a05a079 OP_EQUALVERIFY OP_CHECKSIG"
+                },
+                "address": "16T3RPZLmxtXQCgWi1S8kef5Ca6jqXhoeT"
+              }
+            ]
+          },
+          {
+            "metadata": {
+              "amount": 38043749285,
+              "fee": 20000,
+              "status": "unconfirmed",
+              "confirmations": 73,
+              "block_time": 1415993584376
+            },
+            "version": 1,
+            "lock_time": 0,
+            "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+            "inputs": [
+              {
+                "index": 0,
+                "script_sig": "3046022100be69797cf5d784412b1258256eb657c191a04893479dfa2ae5c7f2088c7adbe0022100e6b000bd633b286ed1b9bc7682fe753d9fdad61fbe5da2a6e9444198e33a670f01",
+                "output": {
+                  "hash": "6b040cd7a4676b5c7b11f144e73c1958c177fcd79e934f6be8ce02c8cd12546d",
+                  "index": 1,
+                  "value": 38043749285,
+                  "script": {
+                    "type": "standard",
+                    "asm": "OP_DUP OP_HASH160 7d4e6d55e1dffb0df85f509343451d170d147551 OP_EQUALVERIFY OP_CHECKSIG"
+                  }
+                }
+              }
+            ],
+            "outputs": [
+              {
+                "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+                "index": 0,
+                "value": 38042249285,
+                "script": {
+                  "type": "standard",
+                  "asm": "OP_DUP OP_HASH160 7d4e6d55e1dffb0df85f509343451d170d147551 OP_EQUALVERIFY OP_CHECKSIG"
+                },
+                "address": "1CRZRBwfuwUaVSPJtd6DBuezbm7XPBHLa1",
+                "metadata": {
+                  "type": "change"
+                }
+              },
+              {
+                "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+                "index": 1,
+                "value": 1500000,
+                "script": {
+                  "type": "standard",
+                  "asm": "OP_DUP OP_HASH160 3bc576e6960a9d45201ba5087e39224d0a05a079 OP_EQUALVERIFY OP_CHECKSIG"
+                },
+                "address": "16T3RPZLmxtXQCgWi1S8kef5Ca6jqXhoeT"
+              }
+            ]
+          },
+          {
+            "metadata": {
+              "amount": 38043749285,
+              "fee": 20000,
+              "status": "unconfirmed",
+              "confirmations": 73,
+              "block_time": 1415993584376
+            },
+            "version": 1,
+            "lock_time": 0,
+            "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+            "inputs": [
+              {
+                "index": 0,
+                "script_sig": "3046022100be69797cf5d784412b1258256eb657c191a04893479dfa2ae5c7f2088c7adbe0022100e6b000bd633b286ed1b9bc7682fe753d9fdad61fbe5da2a6e9444198e33a670f01",
+                "output": {
+                  "hash": "6b040cd7a4676b5c7b11f144e73c1958c177fcd79e934f6be8ce02c8cd12546d",
+                  "index": 1,
+                  "value": 38043749285,
+                  "script": {
+                    "type": "standard",
+                    "asm": "OP_DUP OP_HASH160 7d4e6d55e1dffb0df85f509343451d170d147551 OP_EQUALVERIFY OP_CHECKSIG"
+                  }
+                }
+              }
+            ],
+            "outputs": [
+              {
+                "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+                "index": 0,
+                "value": 38042249285,
+                "script": {
+                  "type": "standard",
+                  "asm": "OP_DUP OP_HASH160 7d4e6d55e1dffb0df85f509343451d170d147551 OP_EQUALVERIFY OP_CHECKSIG"
+                },
+                "address": "1CRZRBwfuwUaVSPJtd6DBuezbm7XPBHLa1",
+                "metadata": {
+                  "type": "change"
+                }
+              },
+              {
+                "hash": "60c1f1a3160042152114e2bba45600a5045711c3a8a458016248acec59653471",
+                "index": 1,
+                "value": 1500000,
+                "script": {
+                  "type": "standard",
+                  "asm": "OP_DUP OP_HASH160 3bc576e6960a9d45201ba5087e39224d0a05a079 OP_EQUALVERIFY OP_CHECKSIG"
+                },
+                "address": "16T3RPZLmxtXQCgWi1S8kef5Ca6jqXhoeT"
+              }
+            ]
+          }
+        ],
+        "valid": true
+      },
+      {
+        "description": "not array",
+        "data": 1,
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/schemas/cosmicrealms.json
+++ b/test/ajv-spec/tests/schemas/cosmicrealms.json
@@ -1,0 +1,118 @@
+[
+  {
+    "description": "schema from cosmicrealms benchmark",
+    "schema": {
+      "name": "test",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "fullName", "age", "zip", "married",
+        "dozen", "dozenOrBakersDozen",
+        "favoriteEvenNumber", "topThreeFavoriteColors",
+        "favoriteSingleDigitWholeNumbers", "favoriteFiveLetterWord",
+        "emailAddresses", "ipAddresses"
+      ],
+      "properties": {
+        "fullName": { "type": "string" },
+        "age": { "type": "integer", "minimum": 0 },
+        "optionalItem": { "type": "string" },
+        "state": { "type": "string" },
+        "city": { "type": "string" },
+        "zip": { "type": "integer", "minimum": 0, "maximum": 99999 },
+        "married": { "type": "boolean" },
+        "dozen": { "type": "integer", "minimum": 12, "maximum": 12 },
+        "dozenOrBakersDozen": { "type": "integer", "minimum": 12, "maximum": 13 },
+        "favoriteEvenNumber": { "type": "integer", "multipleOf": 2 },
+        "topThreeFavoriteColors": {
+          "type": "array", "minItems": 3, "maxItems": 3, "uniqueItems": true,
+          "items": { "type": "string" }
+        },
+        "favoriteSingleDigitWholeNumbers": {
+          "type": "array", "minItems": 1, "maxItems": 10, "uniqueItems": true,
+          "items": { "type": "integer", "minimum": 0, "maximum": 9 }
+        },
+        "favoriteFiveLetterWord": { "type": "string", "minLength": 5, "maxLength": 5 },
+        "emailAddresses": {
+          "type": "array", "minItems": 1, "uniqueItems": true,
+          "items": { "type": "string", "format": "email" }
+        },
+        "ipAddresses": {
+          "type": "array", "uniqueItems": true,
+          "items": { "type": "string", "format": "ipv4" }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "valid data from cosmicrealms benchmark",
+        "data": {
+          "fullName": "John Smith",
+          "state": "CA",
+          "city": "Los Angeles",
+          "favoriteFiveLetterWord": "hello",
+          "emailAddresses": [
+            "NRorsfCYtvB5bKAf1jZMu1GAJzAhhg5lEvh@inTqnn.net",
+            "6tjWtYxjaan2Ivm5QZVhKxImKawRCA6gcqtMEwV1@bB01pCtIBY0F.org",
+            "j68UnHfrHiKwpAm8iYokoMuRTpWUj8bfxspusNFK@COoWeMZL.edu",
+            "qlnrIsYSWCGUQW6f8HL@UBOqUYQQzugVL.uk"
+          ],
+          "dozen": 12,
+          "dozenOrBakersDozen": 13,
+          "favoriteEvenNumber": 24,
+          "married": true,
+          "age": 17,
+          "zip": 65794,
+          "topThreeFavoriteColors": [
+            "blue",
+            "black",
+            "yellow"
+          ],
+          "favoriteSingleDigitWholeNumbers": [
+            2,
+            1,
+            3,
+            9
+          ],
+          "ipAddresses": [
+            "225.234.40.3",
+            "96.216.243.54",
+            "18.126.145.83",
+            "196.17.191.239"
+          ]
+        },
+        "valid": true
+      },
+      {
+        "description": "invalid data",
+        "data": {
+          "state": null,
+          "city": 90912,
+          "zip": [ null ],
+          "married": "married",
+          "dozen": 90912,
+          "dozenOrBakersDozen": null,
+          "favoriteEvenNumber": -1294145,
+          "emailAddresses": [],
+          "topThreeFavoriteColors": [
+            null,
+            null,
+            0.7925170068027211,
+            1.2478632478632479,
+            1.173913043478261,
+            0.4472049689440994
+          ],
+          "favoriteSingleDigitWholeNumbers": [],
+          "favoriteFiveLetterWord": "more than five letters",
+          "ipAddresses": [
+            "55.335.74.758",
+            "191.266.92.805",
+            "193.388.390.250",
+            "269.375.318.49",
+            "120.268.59.140"
+          ]
+        },
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/ajv-spec/tests/schemas/medium.json
+++ b/test/ajv-spec/tests/schemas/medium.json
@@ -1,0 +1,135 @@
+[
+  {
+    "description": "medium schema from jsck benchmark (https://github.com/pandastrike/jsck)",
+    "schema": {
+      "description": "A moderately complex schema with some nesting and value constraints",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "api_server",
+        "transport",
+        "storage",
+        "chain"
+      ],
+      "properties": {
+        "api_server": {
+          "description": "Settings for the HTTP API server",
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "url",
+            "host",
+            "port"
+          ],
+          "properties": {
+            "url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "host": {
+              "type": "string"
+            },
+            "port": {
+              "type": "integer",
+              "minimum": 1000
+            }
+          }
+        },
+        "transport": {
+          "description": "Settings for the Redis tranport",
+          "additionalProperties": false,
+          "required": [
+            "server"
+          ],
+          "properties": {
+            "server": {
+              "type": "string"
+            },
+            "options": {
+              "type": "object"
+            },
+            "queues": {
+              "properties": {
+                "blocking_timeout": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              }
+            }
+          }
+        },
+        "storage": {
+          "description": "Settings for the PostgreSQL storage",
+          "required": [
+            "server",
+            "database",
+            "user"
+          ],
+          "properties": {
+            "server": {
+              "type": "string"
+            },
+            "database": {
+              "type": "string"
+            },
+            "user": {
+              "type": "string"
+            },
+            "options": {
+              "type": "object"
+            }
+          }
+        },
+        "chain": {
+          "description": "Settings for the Chain.com client",
+          "required": [
+            "api_key_id",
+            "api_key_secret"
+          ],
+          "properties": {
+            "api_key_id": {
+              "type": "string"
+            },
+            "api_key_secret": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "valid object from jsck benchmark",
+        "data": {
+          "api_server": {
+            "url": "http://example.com:8998",
+            "host": "example.com",
+            "port": 8998
+          },
+          "transport": {
+            "server": "127.0.0.1:6381",
+            "queues": {
+              "blocking_timeout": 0
+            }
+          },
+          "storage": {
+            "server": "127.0.0.1:5432",
+            "database": "thingy-test",
+            "user": "thingy-test",
+            "password": "password"
+          },
+          "chain": {
+            "api_key_id": "cafebabe",
+            "api_key_secret": "babecafe"
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "not object",
+        "data": 1,
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/json-schema.js
+++ b/test/json-schema.js
@@ -26,6 +26,15 @@ const unsafe = new Set([
   // draft2019-09 only
   'draft2019-09/optional/refOfUnknownKeyword.json/reference of a root arbitrary keyword ',
   'draft2019-09/optional/refOfUnknownKeyword.json/reference of an arbitrary keyword of a sub-schema',
+
+  // ajv tests
+  'rules/if.json/then/else without if should be ignored',
+  'rules/if.json/if without then/else should be ignored',
+  'schemas/cosmicrealms.json/schema from cosmicrealms benchmark',
+  'schemas/advanced.json/advanced schema from z-schema benchmark (https://github.com/zaggino/z-schema)',
+  'issues/27_1_recursive_raml_schema.json/JSON Schema for a standard RAML object (#27)',
+  'issues/62_resolution_scope_change.json/resolution scope change - change folder (#62)',
+  'issues/70_swagger_schema.json/Swagger api schema does not compile (#70)',
 ])
 
 const unsupported = new Set([
@@ -54,6 +63,12 @@ const unsupported = new Set([
   'draft2019-09/unevaluatedProperties.json',
   'draft2019-09/unevaluatedItems.json',
   'draft2019-09/ref.json/ref creates new scope when adjacent to keywords',
+
+  // ajv specific non-standard tests
+  'rules/format.json/whitelisted unknown format is valid',
+  'rules/format.json/validation of URL strings',
+  'rules/format.json/validation of JSON-pointer URI fragment strings',
+  'issues/33_json_schema_latest.json/use latest json schema as v4 (#33)',
 ])
 
 const schemas = [
@@ -131,14 +146,22 @@ function processTest(main, id, file, shouldIngore, requiresLax) {
         const mode = requiresLax(`${id}/${block.description}`) ? 'lax' : 'default'
         const $schemaDefault = schemaVersions.get(main)
         const extraFormats = main === 'draft3' // needs old formats
-        for (const includeErrors of [false, true]) {
-          const opts = { schemas, mode, $schemaDefault, extraFormats, includeErrors }
-          const validate = validator(block.schema, opts)
-          const parse = parser(block.schema, opts)
-          for (const test of block.tests) {
-            if (shouldIngore(`${id}/${block.description}/${test.description}`)) continue
-            t.same(validate(test.data), test.valid, test.description)
-            t.same(parse(JSON.stringify(test.data)).valid, test.valid, test.description)
+        const blockSchemas = [
+          ...(Object.hasOwnProperty.call(block, 'schema') ? [block.schema] : []),
+          ...(block.schemas || []),
+        ]
+        for (const schema of blockSchemas) {
+          for (const includeErrors of [false, true]) {
+            // ajv sometimes specifies just the schema id as "schema"
+            const wrapped = typeof schema === 'string' ? { $ref: schema } : schema
+            const opts = { schemas, mode, $schemaDefault, extraFormats, includeErrors }
+            const validate = validator(wrapped, opts)
+            const parse = parser(wrapped, opts)
+            for (const test of block.tests) {
+              if (shouldIngore(`${id}/${block.description}/${test.description}`)) continue
+              t.same(validate(test.data), test.valid, test.description)
+              t.same(parse(JSON.stringify(test.data)).valid, test.valid, test.description)
+            }
           }
         }
       } catch (e) {
@@ -150,9 +173,27 @@ function processTest(main, id, file, shouldIngore, requiresLax) {
   }
 }
 
+/** JSON Schema Test Suite tests **/
 const testsDir = 'JSON-Schema-Test-Suite/tests'
 processTestDir(testsDir, 'draft4')
 processTestDir(testsDir, 'draft6')
 processTestDir(testsDir, 'draft7')
 processTestDir(testsDir, 'draft3')
 processTestDir(testsDir, 'draft2019-09')
+
+/** ajv tests **/
+schemas.push(
+  ...[
+    require('./ajv-spec/remotes/bar.json'),
+    require('./ajv-spec/remotes/foo.json'),
+    require('./ajv-spec/remotes/buu.json'),
+    require('./ajv-spec/remotes/tree.json'),
+    require('./ajv-spec/remotes/node.json'),
+    require('./ajv-spec/remotes/second.json'),
+    require('./ajv-spec/remotes/first.json'),
+    require('./ajv-spec/remotes/scope_change.json'),
+  ]
+)
+processTestDir('ajv-spec/tests', 'issues')
+processTestDir('ajv-spec/tests', 'rules')
+processTestDir('ajv-spec/tests', 'schemas')

--- a/test/json-schema.js
+++ b/test/json-schema.js
@@ -197,3 +197,4 @@ schemas.push(
 processTestDir('ajv-spec/tests', 'issues')
 processTestDir('ajv-spec/tests', 'rules')
 processTestDir('ajv-spec/tests', 'schemas')
+processTestDir('ajv-spec', 'extras.part')


### PR DESCRIPTION
This introduces a number of tests from ajv.
Total: 3980 -> 4292 = 312 difference.

That's not _all_ the tests ajv has, but those that come in `*.json` format and are semi-compatible with JSON Schema Test Suite (with minor changes).

Origin: https://github.com/ajv-validator/ajv/tree/v6.12.2/spec/tests

Depends on #94.

This helped discover #87, #89, #91, #92. 