### PR TITLE
Use obj.x instead of obj["x"] in common safe cases

### DIFF
--- a/src/generate-function.js
+++ b/src/generate-function.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { format } = require('./safe-format')
+const { format, safe } = require('./safe-format')
 const jaystring = require('./jaystring')
 
 const INDENT_START = /[{[]/
@@ -55,7 +55,9 @@ module.exports = () => {
     },
 
     makeModule(scope = {}) {
-      const scopeDefs = processScope(scope).map(([key, val]) => `const ${key} = ${jaystring(val)};`)
+      const scopeDefs = processScope(scope).map(
+        ([key, val]) => `const ${safe(key)} = ${jaystring(val)};`
+      )
       return `(function() {\n'use strict'\n${scopeDefs.join('\n')}\n${build()}})();`
     },
 

--- a/src/index.js
+++ b/src/index.js
@@ -56,12 +56,14 @@ const buildName = ({ name, parent, keyval, keyname }) => {
     return name // top-level
   }
   if (!parent) throw new Error('Can not use property of undefined parent!')
+  const parentName = buildName(parent)
   if (keyval !== undefined) {
     if (keyname) throw new Error('Can not use key value and name together')
     if (!['string', 'number'].includes(typeof keyval)) throw new Error('Invalid property path')
-    return format('%s[%j]', buildName(parent), keyval)
+    if (/^[a-z][a-z0-9_]*$/i.test(keyval)) return format('%s.%s', parentName, safe(keyval))
+    return format('%s[%j]', parentName, keyval)
   } else if (keyname) {
-    return format('%s[%s]', buildName(parent), keyname)
+    return format('%s[%s]', parentName, keyname)
   }
   /* c8 ignore next */
   throw new Error('Unreachable')

--- a/src/safe-format.js
+++ b/src/safe-format.js
@@ -58,7 +58,7 @@ const format = (fmt, ...args) => {
 }
 
 const safe = (string) => {
-  if (!/^[a-z][a-z0-9]*$/.test(string)) throw new Error('Does not look like a safe id')
+  if (!/^[a-z][a-z0-9_]*$/i.test(string)) throw new Error('Does not look like a safe id')
   return new SafeString(string)
 }
 


### PR DESCRIPTION
Actually, two loosely related changes here.

1) `obj.x` -> `obj["x"]` for properties with names `/^[a-z][a-z0-9_]*$/i`.

    Note how this check is much less complex than what is-my-json-valid had (which attempted to inline _all_ valid property literals, so the regex was quite big). Approach in this PR should be trivial and safe.

    Motivation: to make the generated code a bit more readable.
    I expect that most properties will fit into that regexp.

2) As `safe()` ids now extended to case-insensitive, we can use it to wrap scope keys in `generate-function`, which double-checks that scope keys are safe for inclusion.

