### PR TITLE
Add dependentSchemas support from draft2019-09

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -682,27 +682,31 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
         consume('required', 'array')
       }
 
-      const dependencies = node.dependencies === undefined ? 'dependentRequired' : 'dependencies'
-      if (node[dependencies]) {
-        for (const key of Object.keys(node[dependencies])) {
-          let deps = node[dependencies][key]
-          if (typeof deps === 'string') deps = [deps]
+      for (const dependencies of ['dependencies', 'dependentRequired', 'dependentSchemas']) {
+        if (node[dependencies]) {
+          for (const key of Object.keys(node[dependencies])) {
+            let deps = node[dependencies][key]
+            if (typeof deps === 'string') deps = [deps]
 
-          const exists = (k) => present(currPropImm(k))
-          const item = currPropImm(key)
+            const exists = (k) => present(currPropImm(k))
+            const item = currPropImm(key)
 
-          if (Array.isArray(deps)) {
-            const condition = safeand(...deps.map(exists))
-            errorIf('%s && !(%s)', [present(item), condition], { path: [dependencies, key] })
-          } else if (typeof deps === 'object' || typeof deps === 'boolean') {
-            fun.block('if (%s) {', [present(item)], '}', () => {
-              rule(current, deps, subPath(dependencies, key))
-            })
-          } else {
-            fail('Unexpected dependencies entry')
+            if (Array.isArray(deps) && dependencies !== 'dependentSchemas') {
+              const condition = safeand(...deps.map(exists))
+              errorIf('%s && !(%s)', [present(item), condition], { path: [dependencies, key] })
+            } else if (
+              (typeof deps === 'object' || typeof deps === 'boolean') &&
+              dependencies !== 'dependentRequired'
+            ) {
+              fun.block('if (%s) {', [present(item)], '}', () => {
+                rule(current, deps, subPath(dependencies, key))
+              })
+            } else {
+              fail(`Unexpected ${dependencies} entry`)
+            }
           }
+          consume(dependencies, 'object')
         }
-        consume(dependencies, 'object')
       }
 
       if (typeof node.properties === 'object') {

--- a/src/known-keywords.js
+++ b/src/known-keywords.js
@@ -11,7 +11,7 @@ module.exports = [
   ...['contains', 'minContains', 'maxContains', 'uniqueItems'], // arrays, complex
   ...['maxLength', 'minLength', 'format', 'pattern'], // strings
   ...['properties', 'maxProperties', 'minProperties', 'additionalProperties', 'patternProperties'], // objects
-  ...['propertyNames', 'dependencies', 'dependentRequired'], // objects
+  ...['propertyNames', 'dependencies', 'dependentRequired', 'dependentSchemas'], // objects
   // Unused meta keywords not affecting validation (annotations and comments)
   // https://json-schema.org/understanding-json-schema/reference/generic.html
   ...['description', 'title', 'examples', '$comment'], // unused

--- a/test/json-schema.js
+++ b/test/json-schema.js
@@ -48,7 +48,6 @@ const unsupported = new Set([
 
   //  draft2019-09 is not supported yet
   'draft2019-09/anchor.json',
-  'draft2019-09/dependentSchemas.json',
   'draft2019-09/unevaluatedProperties.json',
   'draft2019-09/unevaluatedItems.json',
   'draft2019-09/defs.json',


### PR DESCRIPTION
`dependentSchemas` and `dependentRequired` behave like two branches of `dependencies` from pre-`draft2019-09` spec versions.

Also add a check that `dependentRequired` entries are not schemas but are arrays.

Most changes are whitespace due to extra indentation level.

We might want to push `draft2019-09` due to `unevaluatedProperties`, which _will_ make things easier if implemented.