### PR TITLE
formats: use a simple non-nested regexp for uuids

### DIFF
--- a/src/formats.js
+++ b/src/formats.js
@@ -61,11 +61,9 @@ const core = {
   // relative JSON-pointer: http://tools.ietf.org/html/draft-luff-relative-json-pointer-00
   'relative-json-pointer': /^(?:0|[1-9][0-9]*)(?:|#|\/(?:[^~]|~0|~1)*)$/,
 
-  // matches ajv + length checks
+  // matches ajv + unwrap nested group
   // uuid: http://tools.ietf.org/html/rfc4122
-  uuid: (input) =>
-    input.length <= 36 + 9 &&
-    /^(?:urn:uuid:)?[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i.test(input),
+  uuid: /^(?:urn:uuid:)?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
 
   // TODO: iri, iri-reference, idn-email, idn-hostname, duration
 }


### PR DESCRIPTION
Also no need for the length check this way.
Tests will be introduced with updated JSON Schema Test Suite.