### PR TITLE
ci: test on 14.x, use a separate workflow for coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,18 @@
+name: Coverage
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14'
+      - run: yarn --frozen-lockfile
+      - run: yarn run coverage:lcov
+      - uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage/lcov.info

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [10.x, 12.x, 14.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -20,9 +20,6 @@ jobs:
         run: |
           yarn --frozen-lockfile
           yarn lint
-          yarn run ci
+          yarn run test
         env:
           CI: true
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage/lcov.info

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint": "prettier --list-different '**/*.js'&& eslint .",
     "format": "prettier --write '**/*.js'",
     "coverage": "c8 --reporter=lcov --reporter=text npm run test",
-    "ci": "c8 --reporter=lcovonly npm run test",
+    "coverage:lcov": "c8 --reporter=lcovonly npm run test",
     "test": "npm run test:normal | tap-spec && npm run test:module | tap-spec",
     "test:raw": "npm run test:normal && npm run test:module",
     "test:module": "tape -r ./test/tools/test-module.js test/*.js test/regressions/*.js",


### PR DESCRIPTION
This way we won't try to run coverage on the whole matrix.