### PR TITLE
Normalize jaystring error messages, add tests

### DIFF
--- a/src/jaystring.js
+++ b/src/jaystring.js
@@ -14,7 +14,7 @@ function jaystring(item) {
     if (item[toJayString]) return item[toJayString] // this is supported only for functions
 
     if (Object.getPrototypeOf(item) !== Function.prototype)
-      throw new Error('Can not stringify a function with unexpected prototype')
+      throw new Error('Can not stringify: a function with unexpected prototype')
 
     const stringified = `${item}`
     if (item.prototype) {
@@ -25,13 +25,13 @@ function jaystring(item) {
       return stringified // Arrow function
 
     // Shortened ES6 object method declaration
-    throw new Error('Can stringify only either normal or arrow functions')
+    throw new Error('Can not stringify: only either normal or arrow functions are supported')
   } else if (typeof item === 'object') {
     const proto = Object.getPrototypeOf(item)
     if (item instanceof RegExp && proto === RegExp.prototype) return format('%r', item)
-    throw new Error('Can not stringify an object with unexpected prototype')
+    throw new Error('Can not stringify: an object with unexpected prototype')
   }
-  throw new Error(`Cannot stringify ${item} - unknown type ${typeof item}`)
+  throw new Error(`Can not stringify: unknown type ${typeof item}`)
 }
 
 module.exports = jaystring

--- a/test/jaystring.js
+++ b/test/jaystring.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const tape = require('tape')
+const { inspect } = require('util')
+const jaystring = require('../src/jaystring')
+
+function foo(bar) {
+  return bar
+}
+
+tape('valid', (t) => {
+  for (const [source, string] of [
+    [() => {}, '() => {}'],
+    [(x) => x * 2, '(x) => x * 2'],
+    [function() {}, 'function() {}'],
+    [foo, 'function foo(bar) {\n  return bar\n}'],
+    [/x/, 'new RegExp("x", "")'],
+    [new RegExp('x\\/', 'i'), 'new RegExp("x\\\\/", "i")'],
+    [/x/g, 'new RegExp("x", "g")'],
+  ]) {
+    t.strictEqual(`${jaystring(source)}`, string, string)
+  }
+
+  t.end()
+})
+
+tape('invalid', (t) => {
+  for (const source of [0, {}, [], { foo() {} }.foo])
+    t.throws(() => jaystring(source), /Can not stringify:/, inspect(source))
+
+  t.end()
+})


### PR DESCRIPTION
Regexp format tests will be added separately, to safe-format.