### PR TITLE
Make errors from $ref validation transparent

### DIFF
--- a/doc/Error-handling.md
+++ b/doc/Error-handling.md
@@ -7,17 +7,6 @@ There are two possible types of errors:
 Schema compilation errors always throw synchronously to ensure that no invalid schemas get compiled
 and/or produce invalid validation code.
 
-## Validation errors
-
-At the moment of writing, correct error reporting is still in progress. \
-Most significant known issue is that error pointers stop at `$ref` usage.
-
-This does not affect the _result_ of the validation, just the information inside of the produced
-error objects.
-
-It's significantly better than in `is-my-json-valid` though.\
-Further improvements should bring this on par with `ajv`.
-
 ### Validation errors are opt-in
 
 Error reporting is disabled by default and is provided as an opt-in, because users who need to

--- a/src/scope-functions.js
+++ b/src/scope-functions.js
@@ -63,4 +63,11 @@ hasOwn[Symbol.for('toJayString')] = 'Function.prototype.call.bind(Object.prototy
 const pointerPart = (s) => (/~\//.test(s) ? `${s}`.replace(/~/g, '~0').replace(/\//g, '~1') : s)
 const toPointer = (path) => (path.length === 0 ? '#' : `#/${path.map(pointerPart).join('/')}`)
 
-module.exports = { stringLength, isMultipleOf, deepEqual, unique, hasOwn, toPointer, pointerPart }
+const errorMerge = ({ schemaPath, dataPath, ...more }, schemaBase, dataBase) => ({
+  schemaPath: `${schemaBase}${schemaPath.slice(1)}`,
+  dataPath: `${dataBase}${dataPath.slice(1)}`,
+  ...more,
+})
+
+const errorUtils = { toPointer, pointerPart, errorMerge }
+module.exports = { stringLength, isMultipleOf, deepEqual, unique, hasOwn, ...errorUtils }

--- a/test/ref-errors.js
+++ b/test/ref-errors.js
@@ -1,0 +1,91 @@
+'use strict'
+
+const tape = require('tape')
+const { validator } = require('..')
+
+const schema = {
+  type: 'object',
+  required: ['hello', 'bar'],
+  properties: {
+    hello: {
+      type: 'string',
+    },
+  },
+  additionalProperties: false,
+}
+
+const data = { hello: 100, boo: 10 }
+
+const schemas = [
+  {
+    $id: 'https://example.com/schema0',
+    $defs: schema,
+  },
+  {
+    $id: 'https://example.com/schema1',
+    $defs: {
+      woo: schema,
+    },
+    $ref: '#/$defs/woo',
+  },
+  {
+    $id: 'https://example.com/schema2',
+    $defs: {
+      woo: {
+        $id: 'woo-id',
+        ...schema,
+      },
+    },
+    $ref: 'woo-id',
+  },
+]
+
+tape('$ref does not break error path', (t) => {
+  const test = (dataPath, schemaPath, wrappedData, wrappedSchema) => {
+    for (const allErrors of [true, false]) {
+      const validate = validator(wrappedSchema, { includeErrors: true, allErrors, schemas })
+
+      t.strictEqual(validate(wrappedData), false, 'result is correct')
+      t.ok(Array.isArray(validate.errors), 'errors are an array')
+      t.strictEqual(validate.errors.length, allErrors ? 3 : 1, 'errors number is correct')
+
+      t.strictEqual(validate.errors[0].dataPath, `#${dataPath}/bar`)
+      t.strictEqual(validate.errors[0].schemaPath, `#${schemaPath}/required`)
+
+      if (allErrors) {
+        t.strictEqual(validate.errors[1].dataPath, `#${dataPath}/hello`)
+        t.strictEqual(validate.errors[1].schemaPath, `#${schemaPath}/properties/hello/type`)
+
+        t.strictEqual(validate.errors[2].dataPath, `#${dataPath}/boo`)
+        t.strictEqual(validate.errors[2].schemaPath, `#${schemaPath}/additionalProperties`)
+      }
+    }
+  }
+
+  test('', '', data, schema)
+  test('/foo', '/properties/foo', { foo: data }, { properties: { foo: schema } })
+  test(
+    '/foo',
+    '/properties/foo/$ref',
+    { foo: data },
+    { $defs: schema, properties: { foo: { $ref: '#/$defs' } } }
+  )
+
+  const schemaRefs = [
+    { $ref: 'https://example.com/schema0#/$defs', $path: '/$ref' },
+    { $ref: 'https://example.com/schema1', $path: '/$ref/$ref' },
+    { $ref: 'https://example.com/schema2', $path: '/$ref/$ref' },
+  ]
+  for (const { $ref, $path } of schemaRefs) {
+    test('', $path, data, { $ref })
+    test('/foo', `/properties/foo${$path}`, { foo: data }, { properties: { foo: { $ref } } })
+    test(
+      '/foo',
+      `/properties/foo${$path}`,
+      { ok: {}, foo: data },
+      { properties: { ok: { not: { $ref } }, foo: { $ref } } }
+    )
+  }
+
+  t.end()
+})


### PR DESCRIPTION
This approach is completely different from what ajv does.
    
This sees "through" `$ref`s, building full error references from the top, and descending into refs like `/something/$ref/path/continues` instead of replacing the whole path with the path where the reference resolves to.
    
This way, it is actually possible to tell where the error originated from, unlike with ajv which makes it hard to understand which schema caused the error in some situations.

Fixes most of #56. `oneOf` (and similar) tbd.