### PR TITLE
Add dynamic unevaluatedItems and unevaluatedProperties support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A code-generating [JSON Schema](https://json-schema.org/) validator that attempts to be reasonably secure.
 
-Supports [draft-04/06/07](doc/Specification-support.md).
+Supports [draft-04/06/07/2019-09](doc/Specification-support.md).
 
 [![Node CI Status](https://github.com/ExodusMovement/schemasafe/workflows/Node%20CI/badge.svg)](https://github.com/ExodusMovement/schemasafe/actions)
 [![npm](https://img.shields.io/npm/v/@exodus/schemasafe.svg)](https://www.npmjs.com/package/@exodus/schemasafe)

--- a/doc/Auditable.md
+++ b/doc/Auditable.md
@@ -2,7 +2,7 @@
 
 Features:
 
-  * Whole module size is ~1100 lines of code.
+  * Whole module size is ~1600 lines of code.
 
   * 0 dependencies on any other packages.
 

--- a/doc/Specification-support.md
+++ b/doc/Specification-support.md
@@ -1,6 +1,6 @@
 # Specification support
 
-Currently supported target JSON Schema versions are `draft04`, `draft06`, `draft07`.
+Currently supported target JSON Schema versions are `draft2019-09`, `draft07`, `draft06`, `draft04`.
 
 If you notice issues with any of those draft versions support, please file an issue here and / or
 a test case to [JSON-Schema-Test-Suite](https://github.com/json-schema-org/JSON-Schema-Test-Suite)

--- a/doc/samples/README.md
+++ b/doc/samples/README.md
@@ -60,8 +60,8 @@ Based on JSON Schema Test Suite for `draft2019-09`.
 | [refRemote](./refRemote.md)                                       | 7     | -                 | -        | -             |
 | [required](./required.md)                                         | 4     | -                 | -        | -             |
 | [type](./type.md)                                                 | 11    | -                 | -        | -             |
-| [unevaluatedItems](./unevaluatedItems.md)                         | 16    | 2                 | -        | -             |
-| [unevaluatedProperties](./unevaluatedProperties.md)               | 18    | 4                 | 1        | -             |
+| [unevaluatedItems](./unevaluatedItems.md)                         | 16    | -                 | -        | -             |
+| [unevaluatedProperties](./unevaluatedProperties.md)               | 18    | -                 | 1        | -             |
 | [uniqueItems](./uniqueItems.md)                                   | 6     | -                 | -        | -             |
 | [optional/bignum](./optional-bignum.md)                           | 9     | -                 | -        | -             |
 | [optional/content](./optional-content.md)                         | 3     | -                 | -        | -             |

--- a/doc/samples/unevaluatedItems.md
+++ b/doc/samples/unevaluatedItems.md
@@ -286,11 +286,45 @@ return ref0
 
 ### Code
 
-**FAILED TO COMPILE**
+```js
+'use strict'
+const hasOwn = Function.prototype.call.bind(Object.prototype.hasOwnProperty);
+const ref0 = function validate(data, recursive) {
+  validate.evaluatedDynamic = null
+  const evaluatedItems0 = [0]
+  const evaluatedProps0 = [], evaluatedPatterns0 = []
+  if (!Array.isArray(data)) return false
+  if (data[0] !== undefined && hasOwn(data, 0)) {
+    if (!(data[0] === "foo")) return false
+  }
+  const sub0 = (() => {
+    if (data[1] !== undefined && hasOwn(data, 1)) {
+      if (!(data[1] === "bar")) return false
+    }
+    return true
+  })()
+  const sub1 = (() => {
+    if (data[2] !== undefined && hasOwn(data, 2)) {
+      if (!(data[2] === "baz")) return false
+    }
+    return true
+  })()
+  if (!(sub0 || sub1)) return false
+  if (sub0) {
+    evaluatedItems0.push(2)
+  }
+  if (sub1) {
+    evaluatedItems0.push(3)
+  }
+  if (data.length > Math.max(1, ...evaluatedItems0)) return false
+  return true
+};
+return ref0
+```
 
-### Errors
+##### Strong mode notices
 
- * `Dynamic unevaluated is not implemented`
+ * `[requireValidation] schema = true is not allowed at #/anyOf/0/0`
 
 
 ## unevaluatedItems with oneOf
@@ -408,11 +442,43 @@ return ref0
 
 ### Code
 
-**FAILED TO COMPILE**
+```js
+'use strict'
+const hasOwn = Function.prototype.call.bind(Object.prototype.hasOwnProperty);
+const ref0 = function validate(data, recursive) {
+  validate.evaluatedDynamic = null
+  const evaluatedItems0 = [0]
+  const evaluatedProps0 = [], evaluatedPatterns0 = []
+  if (!Array.isArray(data)) return false
+  if (data[0] !== undefined && hasOwn(data, 0)) {
+    if (!(data[0] === "foo")) return false
+  }
+  const sub0 = (() => {
+    if (data[1] !== undefined && hasOwn(data, 1)) {
+      if (!(data[1] === "bar")) return false
+    }
+    return true
+  })()
+  if (!sub0) {
+    if (data[3] !== undefined && hasOwn(data, 3)) {
+      if (!(data[3] === "else")) return false
+    }
+    evaluatedItems0.push(4)
+  } else {
+    if (data[2] !== undefined && hasOwn(data, 2)) {
+      if (!(data[2] === "then")) return false
+    }
+    evaluatedItems0.push(3)
+  }
+  if (data.length > Math.max(3, ...evaluatedItems0)) return false
+  return true
+};
+return ref0
+```
 
-### Errors
+##### Strong mode notices
 
- * `Dynamic unevaluated is not implemented`
+ * `[requireValidation] schema = true is not allowed at #/if/0`
 
 
 ## unevaluatedItems with boolean schemas

--- a/doc/samples/unevaluatedProperties.md
+++ b/doc/samples/unevaluatedProperties.md
@@ -357,11 +357,59 @@ return ref0
 
 ### Code
 
-**FAILED TO COMPILE**
+```js
+'use strict'
+const hasOwn = Function.prototype.call.bind(Object.prototype.hasOwnProperty);
+const propertyIn = (key, properties, patterns) =>
+  properties.includes(true) ||
+  properties.some((prop) => prop === key) ||
+  patterns.some((pattern) => new RegExp(pattern, 'u').test(key));
+const ref0 = function validate(data, recursive) {
+  validate.evaluatedDynamic = null
+  const evaluatedItems0 = [0]
+  const evaluatedProps0 = [], evaluatedPatterns0 = []
+  if (!(typeof data === "object" && data && !Array.isArray(data))) return false
+  if (data.foo !== undefined && hasOwn(data, "foo")) {
+    if (!(typeof data.foo === "string")) return false
+  }
+  const sub0 = (() => {
+    if (!(data.bar !== undefined && hasOwn(data, "bar"))) return false
+    if (!(data.bar === "bar")) return false
+    return true
+  })()
+  const sub1 = (() => {
+    if (!(data.baz !== undefined && hasOwn(data, "baz"))) return false
+    if (!(data.baz === "baz")) return false
+    return true
+  })()
+  const sub2 = (() => {
+    if (!(data.quux !== undefined && hasOwn(data, "quux"))) return false
+    if (!(data.quux === "quux")) return false
+    return true
+  })()
+  if (!(sub0 || sub1 || sub2)) return false
+  if (sub0) {
+    evaluatedProps0.push(...["bar"])
+  }
+  if (sub1) {
+    evaluatedProps0.push(...["baz"])
+  }
+  if (sub2) {
+    evaluatedProps0.push(...["quux"])
+  }
+  for (const key0 of Object.keys(data)) {
+    if (key0 !== "foo" && !propertyIn(key0, evaluatedProps0, evaluatedPatterns0)) {
+      return false
+    }
+  }
+  return true
+};
+return ref0
+```
 
-### Errors
+##### Strong mode notices
 
- * `Dynamic unevaluated is not implemented`
+ * `[requireStringValidation] pattern, format or contentSchema must be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## unevaluatedProperties with oneOf
@@ -382,11 +430,54 @@ return ref0
 
 ### Code
 
-**FAILED TO COMPILE**
+```js
+'use strict'
+const hasOwn = Function.prototype.call.bind(Object.prototype.hasOwnProperty);
+const propertyIn = (key, properties, patterns) =>
+  properties.includes(true) ||
+  properties.some((prop) => prop === key) ||
+  patterns.some((pattern) => new RegExp(pattern, 'u').test(key));
+const ref0 = function validate(data, recursive) {
+  validate.evaluatedDynamic = null
+  const evaluatedItems0 = [0]
+  const evaluatedProps0 = [], evaluatedPatterns0 = []
+  if (!(typeof data === "object" && data && !Array.isArray(data))) return false
+  if (data.foo !== undefined && hasOwn(data, "foo")) {
+    if (!(typeof data.foo === "string")) return false
+  }
+  let passes0 = 0
+  const sub0 = (() => {
+    if (!(data.bar !== undefined && hasOwn(data, "bar"))) return false
+    if (!(data.bar === "bar")) return false
+    return true
+  })()
+  if (sub0) passes0++
+  const sub1 = (() => {
+    if (!(data.baz !== undefined && hasOwn(data, "baz"))) return false
+    if (!(data.baz === "baz")) return false
+    return true
+  })()
+  if (sub1) passes0++
+  if (passes0 !== 1) return false
+  if (sub0) {
+    evaluatedProps0.push(...["bar"])
+  }
+  if (sub1) {
+    evaluatedProps0.push(...["baz"])
+  }
+  for (const key0 of Object.keys(data)) {
+    if (key0 !== "foo" && !propertyIn(key0, evaluatedProps0, evaluatedPatterns0)) {
+      return false
+    }
+  }
+  return true
+};
+return ref0
+```
 
-### Errors
+##### Strong mode notices
 
- * `Dynamic unevaluated is not implemented`
+ * `[requireStringValidation] pattern, format or contentSchema must be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## unevaluatedProperties with not
@@ -461,11 +552,45 @@ return ref0
 
 ### Code
 
-**FAILED TO COMPILE**
+```js
+'use strict'
+const hasOwn = Function.prototype.call.bind(Object.prototype.hasOwnProperty);
+const propertyIn = (key, properties, patterns) =>
+  properties.includes(true) ||
+  properties.some((prop) => prop === key) ||
+  patterns.some((pattern) => new RegExp(pattern, 'u').test(key));
+const ref0 = function validate(data, recursive) {
+  validate.evaluatedDynamic = null
+  const evaluatedItems0 = [0]
+  const evaluatedProps0 = [], evaluatedPatterns0 = []
+  if (!(typeof data === "object" && data && !Array.isArray(data))) return false
+  const sub0 = (() => {
+    if (!(data.foo !== undefined && hasOwn(data, "foo"))) return false
+    if (!(data.foo === "then")) return false
+    return true
+  })()
+  if (!sub0) {
+    if (!(data.baz !== undefined && hasOwn(data, "baz"))) return false
+    if (!(typeof data.baz === "string")) return false
+    evaluatedProps0.push(...["baz"])
+  } else {
+    if (!(data.bar !== undefined && hasOwn(data, "bar"))) return false
+    if (!(typeof data.bar === "string")) return false
+    evaluatedProps0.push(...["foo","bar"])
+  }
+  for (const key0 of Object.keys(data)) {
+    if (true && !propertyIn(key0, evaluatedProps0, evaluatedPatterns0)) {
+      return false
+    }
+  }
+  return true
+};
+return ref0
+```
 
-### Errors
+##### Strong mode notices
 
- * `Dynamic unevaluated is not implemented`
+ * `[requireStringValidation] pattern, format or contentSchema must be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/else/properties/baz`
 
 
 ## unevaluatedProperties with dependentSchemas
@@ -485,11 +610,39 @@ return ref0
 
 ### Code
 
-**FAILED TO COMPILE**
+```js
+'use strict'
+const hasOwn = Function.prototype.call.bind(Object.prototype.hasOwnProperty);
+const propertyIn = (key, properties, patterns) =>
+  properties.includes(true) ||
+  properties.some((prop) => prop === key) ||
+  patterns.some((pattern) => new RegExp(pattern, 'u').test(key));
+const ref0 = function validate(data, recursive) {
+  validate.evaluatedDynamic = null
+  const evaluatedItems0 = [0]
+  const evaluatedProps0 = [], evaluatedPatterns0 = []
+  if (!(typeof data === "object" && data && !Array.isArray(data))) return false
+  if (data.foo !== undefined && hasOwn(data, "foo")) {
+    if (!(data.bar !== undefined && hasOwn(data, "bar"))) return false
+    if (!(data.bar === "bar")) return false
+    evaluatedProps0.push(...["bar"])
+  }
+  if (data.foo !== undefined && hasOwn(data, "foo")) {
+    if (!(typeof data.foo === "string")) return false
+  }
+  for (const key0 of Object.keys(data)) {
+    if (key0 !== "foo" && !propertyIn(key0, evaluatedProps0, evaluatedPatterns0)) {
+      return false
+    }
+  }
+  return true
+};
+return ref0
+```
 
-### Errors
+##### Strong mode notices
 
- * `Dynamic unevaluated is not implemented`
+ * `[requireStringValidation] pattern, format or contentSchema must be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## unevaluatedProperties with boolean schemas

--- a/src/scope-functions.js
+++ b/src/scope-functions.js
@@ -93,5 +93,10 @@ const errorMerge = ({ keywordLocation, instanceLocation, ...more }, schemaBase, 
   ...more,
 })
 
-const errorUtils = { toPointer, pointerPart, errorMerge }
-module.exports = { stringLength, isMultipleOf, deepEqual, unique, deBase64, hasOwn, ...errorUtils }
+const propertyIn = (key, properties, patterns) =>
+  properties.includes(true) ||
+  properties.some((prop) => prop === key) ||
+  patterns.some((pattern) => new RegExp(pattern, 'u').test(key))
+
+const extraUtils = { toPointer, pointerPart, errorMerge, propertyIn }
+module.exports = { stringLength, isMultipleOf, deepEqual, unique, deBase64, hasOwn, ...extraUtils }

--- a/src/tracing.js
+++ b/src/tracing.js
@@ -87,4 +87,4 @@ const isDynamic = wrapFun(({ unknown, items, dyn, ...stat }) => ({
   properties: !stat.properties.includes(true) && (unknown || !inProperties(stat, dyn)),
 }))
 
-module.exports = { initTracing, andDelta, orDelta, applyDelta, isDynamic }
+module.exports = { initTracing, andDelta, orDelta, applyDelta, isDynamic, inProperties }

--- a/test/json-schema.js
+++ b/test/json-schema.js
@@ -62,14 +62,6 @@ const unsupported = new Set([
   'draft3/ref.json/remote ref, containing refs itself',
   'draft3/optional/ecmascript-regex.json/ECMA 262 regex dialect recognition', // broken assumption in test
 
-  //  draft2019-09 is not supported yet
-  'draft2019-09/unevaluatedItems.json/unevaluatedItems with anyOf',
-  'draft2019-09/unevaluatedItems.json/unevaluatedItems with if/then/else',
-  'draft2019-09/unevaluatedProperties.json/unevaluatedProperties with anyOf',
-  'draft2019-09/unevaluatedProperties.json/unevaluatedProperties with oneOf',
-  'draft2019-09/unevaluatedProperties.json/unevaluatedProperties with if/then/else',
-  'draft2019-09/unevaluatedProperties.json/unevaluatedProperties with dependentSchemas',
-
   // ajv specific non-standard tests
   'rules/format.json/whitelisted unknown format is valid',
   'rules/format.json/validation of URL strings',


### PR DESCRIPTION
~Depends on a bunch of other PRs.~

Static `unevaluatedItems` / `unevaluatedProperties` already landed to master and [28 out of 34](https://github.com/ExodusMovement/schemasafe/tree/master/doc/samples) tests work on that, with the remaining safely refusing to compile (as dynamic tracing is not enabled yet in master).

This PR adds support for dynamic tracing so that everything will work.

Draft for now.