### PR TITLE
Enable dataPath in all errors, rename verboseErrors to reflectErrorsValue

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,16 +74,14 @@ console.log(validate('hello')) // true
 console.log(validate(42)) // false
 ```
 
-## Verbose mode shows more information about the source of the error
+## Enabling errors shows information about the source of the error
 
-When the `includeErrors` and `verboseErrors` options are set to `true`, `@exodus/schemasafe` also
-outputs:
+When the `includeErrors` option is set to `true`, `@exodus/schemasafe` also outputs:
 
 - `schemaPath`: a JSON pointer string as an URI fragment indicating which sub-schema failed, e.g.
   `#/properties/item/type`
 - `dataPath`: a JSON pointer string as an URI fragment indicating which property of the object
   failed validation, e.g. `#/item`
-- `value`: The data value that caused the error
 
 ```js
 const schema = {
@@ -95,17 +93,15 @@ const schema = {
     }
   }
 }
-const validate = validator(schema, {
-  includeErrors: true,
-  verboseErrors: true
-})
+const validate = validator(schema, { includeErrors: true })
 
 validate({ hello: 100 });
 console.log(validate.errors)
 // [ { schemaPath: '#/properties/hello/type',
-//     dataPath: '#/hello',
-//     value: 100 } ]
+//     dataPath: '#/hello' } ]
 ```
+
+See [Error handling](./doc/Error-handling.md) for more information.
 
 ## Generate Modules
 

--- a/doc/Error-handling.md
+++ b/doc/Error-handling.md
@@ -41,6 +41,29 @@ The options relevant to error reporting are:
     will be skipped if the parent data object (containing the property) failed other restrictions.\
     That does not affect the result of validation, just the list of reported errors in those cases.
 
-  * `verboseErrors` — include more information in each error object. Requires `includeErrors`.
+  * `reflectErrorsValue` — include `value` property in errors with the data that failed validation.
+    Requires `includeErrors`.
+
+    Warning: `reflectErrorsValue` reflects the original _unvalidated_ value as the `value` property
+    of each error, which is a _reference_ to the part of the orignal unvalidated object which failed
+    validation.
+
+    If the input was untrusted, then `value` property also should be treated as untrusted, e.g.
+    when manipulating it and/or reflecting it back to the user.
 
 All of those are opt-ins (i.e. `false` by default).
+
+### Properties
+
+  - `schemaPath`: a JSON pointer string as an URI fragment indicating which sub-schema failed, e.g.
+  `#/properties/item/type`
+
+  - `dataPath`: a JSON pointer string as an URI fragment indicating which property of the object
+  failed validation, e.g. `#/item`
+
+  - `value`: the _unvalidated_ data value that caused the error. Enabled only when
+  `reflectErrorsValue` is set to true. Use with care.
+
+  - `message`: can be present for certain generic validation errors, e.g. failed `jsonCheck`.
+  Absent for most errors, as the exact keyword which failed validation can be deduced from
+  `schemaPath`, and an additional error message would have just duplicated that information.

--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
     removeAdditional = false, // supports additionalProperties: false and additionalItems: false
     includeErrors: optIncludeErrors = false,
     allErrors: optAllErrors = false,
-    verboseErrors = false,
+    reflectErrorsValue = false,
     dryRun = false,
     allowUnusedKeywords = opts.mode === 'lax',
     requireValidation = opts.mode === 'strong',
@@ -204,7 +204,7 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
       const schemaP = functions.toPointer([...schemaPath, ...path])
       const dataP = buildPath(prop)
       if (includeErrors === true) {
-        const errorJS = verboseErrors
+        const errorJS = reflectErrorsValue
           ? format('{ schemaPath: %j, dataPath: %s, value: %s }', schemaP, dataP, buildName(prop))
           : format('{ schemaPath: %j, dataPath: %s }', schemaP, dataP)
         if (allErrors) {

--- a/src/index.js
+++ b/src/index.js
@@ -206,7 +206,7 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
       if (includeErrors === true) {
         const errorJS = verboseErrors
           ? format('{ schemaPath: %j, dataPath: %s, value: %s }', schemaP, dataP, buildName(prop))
-          : format('{ schemaPath: %j }', schemaP)
+          : format('{ schemaPath: %j, dataPath: %s }', schemaP, dataP)
         if (allErrors) {
           fun.write('if (validate.errors === null) validate.errors = []')
           fun.write('validate.errors.push(%s)', errorJS)

--- a/src/scope-functions.js
+++ b/src/scope-functions.js
@@ -68,10 +68,12 @@ const hasOwn = Function.prototype.call.bind(Object.prototype.hasOwnProperty)
 // special handling for stringification
 hasOwn[Symbol.for('toJayString')] = 'Function.prototype.call.bind(Object.prototype.hasOwnProperty)'
 
-// Used for error generation
+// Used for error generation. Affects error performance, optimized
 function toPointer(path) {
   if (path.length === 0) return '#'
-  return `#/${path.map((part) => `${part}`.replace(/~/g, '~0').replace(/\//g, '~1')).join('/')}`
+  const esc = (part) =>
+    /~\//.test(part) ? `${part}`.replace(/~/g, '~0').replace(/\//g, '~1') : part
+  return `#/${path.map(esc).join('/')}`
 }
 
 module.exports = { stringLength, isMultipleOf, deepEqual, unique, hasOwn, toPointer }

--- a/test/data-path.js
+++ b/test/data-path.js
@@ -14,7 +14,7 @@ tape('dataPath', (t) => {
       },
     },
   }
-  const validate = validator(schema, { includeErrors: true, verboseErrors: true })
+  const validate = validator(schema, { includeErrors: true })
 
   const checkError = (data, schemaPath, dataPath, message) => {
     t.deepEqual(validate(data), false, `should have failed: ${message}`)

--- a/test/misc.js
+++ b/test/misc.js
@@ -104,10 +104,7 @@ tape('additional props', function(t) {
       type: 'object',
       additionalProperties: false,
     },
-    {
-      includeErrors: true,
-      verboseErrors: true,
-    }
+    { includeErrors: true, reflectErrorsValue: true }
   )
 
   t.ok(validate({}))
@@ -431,7 +428,7 @@ tape('verbose mode', function(t) {
     },
   }
 
-  const validate = validator(schema, { includeErrors: true, verboseErrors: true })
+  const validate = validator(schema, { includeErrors: true, reflectErrorsValue: true })
 
   t.ok(validate({ hello: 'string' }), 'should be valid')
   t.notOk(validate({ hello: 100 }), 'should not be valid')
@@ -460,7 +457,7 @@ tape('additional props in verbose mode', function(t) {
     },
   }
 
-  const validate = validator(schema, { includeErrors: true, verboseErrors: true })
+  const validate = validator(schema, { includeErrors: true, reflectErrorsValue: true })
 
   validate({ 'hello world': { bar: 'string' } })
 
@@ -496,7 +493,7 @@ tape('field shows item index in arrays', function(t) {
     },
   }
 
-  const validate = validator(schema, { includeErrors: true, verboseErrors: true })
+  const validate = validator(schema, { includeErrors: true, reflectErrorsValue: true })
 
   validate([[{ foo: 'test' }, { foo: 'test' }], [{ foo: 'test' }, { baz: 'test' }]])
 

--- a/test/misc.js
+++ b/test/misc.js
@@ -48,7 +48,7 @@ tape('allErrors/false', function(t) {
       },
       required: ['x', 'y'],
     },
-    { includeErrors: true, verboseErrors: true, allErrors: false }
+    { includeErrors: true, allErrors: false }
   )
   t.notOk(validate({}), 'should be invalid')
   t.strictEqual(validate.errors.length, 1)
@@ -76,7 +76,7 @@ tape('allErrors/true', function(t) {
       },
       required: ['x', 'y'],
     },
-    { includeErrors: true, verboseErrors: true, allErrors: true }
+    { includeErrors: true, allErrors: true }
   )
   t.notOk(validate({}), 'should be invalid')
   t.strictEqual(validate.errors.length, 2)
@@ -412,7 +412,7 @@ tape('nested required array decl', function(t) {
     required: ['x'],
   }
 
-  const validate = validator(schema, { includeErrors: true, verboseErrors: true })
+  const validate = validator(schema, { includeErrors: true })
 
   t.ok(validate({ x: {} }), 'should be valid')
   t.notOk(validate({}), 'should not be valid')

--- a/test/schema-path.js
+++ b/test/schema-path.js
@@ -196,7 +196,7 @@ tape('schemaPath - nested selectors', function(t) {
       },
     ],
   }
-  const validate = validator(schema, { includeErrors: true, verboseErrors: true })
+  const validate = validator(schema, { includeErrors: true })
   t.notOk(validate({ nestedSelectors: 'nope' }), 'should not crash on visit inside *Of')
 
   t.end()


### PR DESCRIPTION
Depends on #110.

Can be done now with a speedup of `dataPath` from #110 and this PR.