### PR TITLE
Remove useless null coercion

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -189,8 +189,6 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
 
   const fun = genfun()
   fun.write('function validate(data) {')
-  // Since undefined is not a valid JSON value, we coerce to null and other checks will catch this
-  fun.write('if (data === undefined) data = null')
   if (optIncludeErrors) fun.write('validate.errors = null')
   fun.write('let errors = 0')
 


### PR DESCRIPTION
Our checks below work correctly with `undefined`, a lot has changed since `is-my-json-valid`.