### PR TITLE
Use deepEqual only when needed, optimize multipleOf and maxLength

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -766,7 +766,9 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
         return true
       } else if (node.enum) {
         enforce(Array.isArray(node.enum), 'Invalid enum')
-        const condition = safeor(...node.enum.map((value) => compare(name, value)))
+        const objects = node.enum.filter((value) => value && typeof value === 'object')
+        const primitive = node.enum.filter((value) => !(value && typeof value === 'object'))
+        const condition = safeor(...[...primitive, ...objects].map((value) => compare(name, value)))
         errorIf('!(%s)', [condition], { path: ['enum'] })
         consume('enum', 'array')
         return true

--- a/src/index.js
+++ b/src/index.js
@@ -477,14 +477,16 @@ const compile = (schema, root, opts, scope, basePathRoot) => {
       if (node.maxLength !== undefined) {
         enforce(Number.isFinite(node.maxLength), 'Invalid maxLength:', node.maxLength)
         scope.stringLength = functions.stringLength
-        errorIf('stringLength(%s) > %d', [name, node.maxLength], { path: ['maxLength'] })
+        const args = [name, node.maxLength, name, node.maxLength]
+        errorIf('%s.length > %d && stringLength(%s) > %d', args, { path: ['maxLength'] })
         consume('maxLength', 'natural')
       }
 
       if (node.minLength !== undefined) {
         enforce(Number.isFinite(node.minLength), 'Invalid minLength:', node.minLength)
         scope.stringLength = functions.stringLength
-        errorIf('stringLength(%s) < %d', [name, node.minLength], { path: ['minLength'] })
+        const args = [name, node.minLength, name, node.minLength]
+        errorIf('%s.length < %d || stringLength(%s) < %d', args, { path: ['minLength'] })
         consume('minLength', 'natural')
       }
 

--- a/src/scope-functions.js
+++ b/src/scope-functions.js
@@ -2,7 +2,8 @@
 
 // for correct Unicode code points processing
 // https://mathiasbynens.be/notes/javascript-unicode#accounting-for-astral-symbols
-const stringLength = (string) => [...string].length
+const stringLength = (string) =>
+  /[\uD800-\uDFFF]/.test(string) ? [...string].length : string.length
 
 const isMultipleOf = (value, multipleOf) => {
   if (typeof multipleOf !== 'number' || !Number.isFinite(value))

--- a/src/scope-functions.js
+++ b/src/scope-functions.js
@@ -5,24 +5,14 @@
 const stringLength = (string) =>
   /[\uD800-\uDFFF]/.test(string) ? [...string].length : string.length
 
-const isMultipleOf = (value, multipleOf) => {
-  if (typeof multipleOf !== 'number' || !Number.isFinite(value))
-    throw new Error('multipleOf is not a number')
-  if (typeof value !== 'number' || !Number.isFinite(value)) return false
-  if (value === 0) return true
-  if (multipleOf === 0) return false
-  const digitsAfterDot = (number) => {
-    if ((number | 0) === number) return 0
-    return String(number)
-      .split('.')
-      .pop().length
-  }
-  const digits = digitsAfterDot(multipleOf)
-  if (digits === 0) return value % multipleOf === 0
-  const valueDigits = digitsAfterDot(value)
-  if (valueDigits > digits) return false
-  const factor = Math.pow(10, digits)
-  return Math.round(factor * value) % Math.round(factor * multipleOf) === 0
+// A isMultipleOf B: shortest decimal denoted as A % shortest decimal denoted as B === 0
+// Optimized, sanity checks and precomputation are outside of this method
+const isMultipleOf = (value, divisor, factor, factorMultiple) => {
+  if (value % divisor === 0) return true
+  const multiple = value * factor
+  if (multiple % factorMultiple === 0) return true
+  const normal = Math.floor(multiple + 0.5)
+  return normal / factor === value && normal % factorMultiple === 0
 }
 
 // supports only JSON-stringifyable objects, defaults to false for unsupported


### PR DESCRIPTION
Also cleaner code for `compare()`.

Also optimize `stringLength` and avoid using arrays when `.length` fails restriction.
Inline check ensures that we don't create arrays out of too large strings that are far above the `maxLength` restriction.
