### PR TITLE
parser: embed first error in concise form if errors are enabled

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -930,11 +930,11 @@ const parser = function(schema, opts = {}) {
     if (typeof src !== 'string') throw new Error('Invalid type!')
     const data = JSON.parse(src)
     if (validate(data)) return data
-    const message = validate.errors
-      ? validate.errors.map((err) => `${err.schemaPath} ${err.message}`).join('\n')
-      : ''
-    const error = new Error(`JSON validation error${message ? `: ${message}` : ''}`)
-    error.errors = validate.errors
+    const reason = validate.errors ? validate.errors[0] : null
+    const keyword = reason && reason.schemaPath ? reason.schemaPath.replace(/.*\//, '') : '??'
+    const explanation = reason ? ` for ${keyword} at ${reason.dataPath}` : ''
+    const error = new Error(`JSON validation failed${explanation}`)
+    if (validate.errors) error.errors = validate.errors
     throw error
   }
   parse.toModule = () =>


### PR DESCRIPTION
If full errors are needed (and enabled), they can be accessed via the the `errors` property, as documented.
    
No reason to attempt to format all of them into the error message, that was both not pretty and broken, as 'message' was removed and those didn't include `dataPath`.

Also don't set undefined `errors` if errors are not enabled.

Tests included.

Example error messages (one per line):
* `JSON validation failed for type at #`
* `JSON validation failed for required at #/foo`
* `JSON validation failed for const at #/foo`
* `JSON validation failed for additionalProperties at #/abc`

Only the first error is embedded into the error message now, others are accessible via `errors` property (if enabled).