### PR TITLE
tests: add failing test case

### DIFF
--- a/test/extra-tests/ref.383.json
+++ b/test/extra-tests/ref.383.json
@@ -447,5 +447,63 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "$ref used in propertyNames with draft 2019-09",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema#",
+            "definitions": {
+                "keys": {
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "propertyNames": {
+                "$ref": "#/definitions/keys"
+            }
+        },
+        "tests": [
+            {
+                "description": "has no property",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "has string property",
+                "data": {
+                    "foo": true
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "$ref used in propertyNames with draft 07",
+        "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "definitions": {
+                "keys": {
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "propertyNames": {
+                "$ref": "#/definitions/keys"
+            }
+        },
+        "tests": [
+            {
+                "description": "has no property",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "has string property",
+                "data": {
+                    "foo": true
+                },
+                "valid": true
+            }
+        ]
     }
 ]


### PR DESCRIPTION
This adds test cases to demonstrate #138 
I am not really sure where to start fixing this. It is important to note that the case using draft 2019-09 passes, while it fails when using draft 07.
If there is any direction you can point me to, I will try to fix this.