### PR TITLE
test: show that $ref behave differently in 2019-09 vs 07

### DIFF
--- a/test/extra-tests/ref.json
+++ b/test/extra-tests/ref.json
@@ -56,5 +56,53 @@
                 "valid": true
             }
         ]
+    },
+    {
+        "description": "$ref does not contain object with draft 2019-09",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema#",
+            "definitions": {
+                "x": {
+                    "properties": {
+                        "test": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "type": "object",
+            "$ref": "#/definitions/x"
+        },
+        "tests": [
+            {
+                "description": "has no property",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "$ref does not contain object with draft 07",
+        "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "definitions": {
+                "x": {
+                    "properties": {
+                        "test": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "type": "object",
+            "$ref": "#/definitions/x"
+        },
+        "tests": [
+            {
+                "description": "has no property",
+                "data": {},
+                "valid": true
+            }
+        ]
     }
 ]


### PR DESCRIPTION
 ✖ Error: Unprocessed keywords: ["type"] at #

Without $schema it work. But when I add $schema in one of the [SchemaStore file](https://github.com/SchemaStore/schemastore), the build broke.
