### PR TITLE
Support unused options in const or enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,3 +253,17 @@ versions.
 ## License
 
 [MIT](./LICENSE)
+
+## Contributing
+
+Get a fully set up development environment with:
+
+```sh
+git clone https://github.com/ExodusMovement/schemasafe
+cd schemasafe
+
+yarn lint
+git submodule update --init --recursive
+
+yarn test
+```

--- a/src/compile.js
+++ b/src/compile.js
@@ -912,7 +912,11 @@ const compileSchema = (schema, root, opts, scope, basePathRoot = '') => {
       if (prev !== null) fun.write('const %s = errorCount', prev)
       if (checkConst()) {
         // const/enum shouldn't have any other validation rules except for already checked type/$ref
-        enforce(unused.size === 0, 'Unexpected keywords mixed with const or enum:', [...unused])
+        enforce(
+          unused.size === 0 || allowUnusedKeywords,
+          'Unexpected keywords mixed with const or enum:',
+          [...unused]
+        )
         const typeKeys = [...types.keys()] // we don't extract type from const/enum, it's enough that we know that it's present
         evaluateDelta({ properties: [true], items: Infinity, type: typeKeys, fullstring: true }) // everything is evaluated for const
         return

--- a/test/options.js
+++ b/test/options.js
@@ -79,3 +79,40 @@ tape('removeAdditional', (t) => {
   )
   t.end()
 })
+
+tape('allowUnusedKeywords includes enums', (t) => {
+  const run = (schema, options, value) => [validator(schema, options)(value), value]
+
+  const schema = {
+    title: "JSON schema for the TypeScript compiler's configuration file",
+    $schema: 'http://json-schema.org/draft-04/schema#',
+    id: 'https://json.schemastore.org/tsconfig',
+    definitions: {
+      compilerOptionsDefinition: {
+        properties: {
+          compilerOptions: {
+            type: 'object',
+            properties: {
+              x: {
+                description: 'y.',
+                enum: ['1', '2', '3'],
+                // This is what the test is checking
+                markdownDescription: 'z',
+              },
+            },
+          },
+        },
+      },
+    },
+    type: 'object',
+    allOf: [
+      {
+        $ref: '#/definitions/compilerOptionsDefinition',
+      },
+    ],
+  }
+
+  t.deepEqual(run(schema, { allowUnusedKeywords: true }, { x: 1 }), [true, { x: 1 }], '')
+
+  t.end()
+})


### PR DESCRIPTION
Hi!

I was updating the TypeScript tsconfig JSON schema ( https://github.com/SchemaStore/schemastore/pull/1534/ ) and hit this case where `allowUnusedKeywords` wasn't being respected, I'm sorry for the size of the test, but I don't have enough experience writing schemas to know if a terser one is possible.