### PR TITLE
feat: experimental linter mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Supports [draft-04/06/07/2019-09/2020-12](doc/Specification-support.md) and the
   [`discriminator` OpenAPI keyword](./doc/Discriminator-support.md).
 * Can assign defaults and/or remove additional properties when schema allows to do that safely.
   Throws at build time if those options are used with schemas that don't allow to do that safely.
+* Can use used as a [schema linter](./doc/Linter.md).
 
 ## Installation
 

--- a/doc/Linter.md
+++ b/doc/Linter.md
@@ -1,0 +1,30 @@
+# Linter mode
+
+**[Experimental]**
+
+`@exodus/schemasafe` can also function in a linter mode, collecting all schema
+errors instead of throwing on the first one.
+
+Usage:
+
+```cjs
+const { lint } = require('@exodus/schemasafe')
+const fs = require('fs')
+const path = require('path')
+
+const dir = 'schemas/json'
+const files = fs.readdirSync(dir).sort().map(x => path.join(dir, x))
+const schemas = files.map(x => [x, JSON.parse(fs.readFileSync(x, 'utf-8'))])
+
+for (const [name, schema] of schemas) {
+  const errors = lint(schema) // lint(schema, { mode: 'strong' })
+  for (const e of errors) {
+    console.log(`${name}: ${e.message}`)
+  }
+}
+```
+
+Other [options](./Options.md) are similar to `parser()` and `validator()` modes.
+
+**Warning:** Exact output messages/details are experimental and might change in
+non-major versions.

--- a/doc/Options.md
+++ b/doc/Options.md
@@ -27,7 +27,11 @@
     keyword and raise an error at compile time unless `allowUnusedKeywords` option is enabled.
 
   * `dryRun` — `false` by default.\
-    Don't produce a validator, just verify the schema.
+    Don't produce a validator, just verify the schema and throw on first error.
+
+  * `lint` — `false` by default.\
+    Don't produce a validator, just verify the schema and collect all errors.
+    Same as [Linter mode](./Linter.md).
 
   * `$schemaDefault` — `null` by default.\
     Can not be used if `requireSchema` is on.

--- a/index.d.ts
+++ b/index.d.ts
@@ -107,6 +107,7 @@ interface ValidatorOptions {
   allErrors?: boolean
   contentValidation?: boolean
   dryRun?: boolean
+  lint?: boolean
   allowUnusedKeywords?: boolean
   allowUnreachable?: boolean
   requireSchema?: boolean
@@ -137,18 +138,28 @@ interface Parse {
   toJSON(): Schema
 }
 
+interface LintError {
+  message: string
+  keywordLocation: string
+  schema: Schema
+}
+
 declare const validator: (schema: Schema, options?: ValidatorOptions) => Validate
 
 declare const parser: (schema: Schema, options?: ValidatorOptions) => Parse
 
+declare const lint: (schema: Schema, options?: ValidatorOptions) => LintError[]
+
 export {
   validator,
   parser,
+  lint,
   Validate,
   ValidationError,
   ValidatorOptions,
   ParseResult,
   Parse,
+  LintError,
   Json,
   Schema,
 }

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@ const validator = (
   const options = { mode, ...opts, schemas: buildSchemas(schemas, arg), isJSON: willJSON }
   const { scope, refs } = compile(arg, options) // only a single ref
   if (opts.dryRun) return
+  if (opts.lint) return scope.lintErrors
   const fun = genfun()
   if (parse) {
     scope.parseWrap = opts.includeErrors ? parseWithErrors : parseWithoutErrors
@@ -89,4 +90,9 @@ const parser = function(schema, { parse = true, ...opts } = {}) {
   return validator(schema, { parse, ...opts })
 }
 
-module.exports = { validator, parser }
+const lint = function(schema, { lint: lintOption = true, ...opts } = {}) {
+  if (!lintOption) throw new Error('can not disable lint option in lint()')
+  return validator(schema, { lint: lintOption, ...opts })
+}
+
+module.exports = { validator, parser, lint }


### PR DESCRIPTION
Usage example:
```cjs
const { validator } = require('@exodus/schemasafe')
const fs = require('fs')
const path = require('path')

const dir = 'schemas/json'
const files = fs.readdirSync(dir).sort().map(x => path.join(dir, x))
const schemas = files.map(x => [x, JSON.parse(fs.readFileSync(x, 'utf-8'))])

for (const [name, schema] of schemas) {
  try {
    //validator(schema, { requireValidation: true  })
    const errors = validator(schema, { lint: true })
    for (const e of errors) {
      console.log(name, ': ', e.message)
    }
  } catch (e) {
    console.log(name, ': ', e)
  }
}
```