### PR TITLE
feat: don't require full top-level validation in non-cyclic-non-top-level refs

### DIFF
--- a/doc/samples/draft-next/anchor.md
+++ b/doc/samples/draft-next/anchor.md
@@ -177,7 +177,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at http://localhost:1234/draft-next/child1#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #`
 
 
 ## non-schema object containing an $anchor property

--- a/doc/samples/draft-next/dynamicRef.md
+++ b/doc/samples/draft-next/dynamicRef.md
@@ -39,7 +39,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at https://test.json-schema.org/dynamicRef-dynamicAnchor-same-schema/root#`
+ * `[requireValidation] type should be specified at #/items`
 
 
 ## A $ref to a $dynamicAnchor in the same schema resource behaves like a normal $ref to an $anchor
@@ -78,7 +78,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at https://test.json-schema.org/ref-dynamicAnchor-same-schema/root#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/items`
 
 
 ## A $dynamicRef resolves to the first $dynamicAnchor still in scope that is encountered when the schema is evaluated
@@ -240,7 +240,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireValidation] type should be specified at https://test.json-schema.org/dynamic-resolution-ignores-anchors/list#`
+ * `[requireValidation] type should be specified at https://test.json-schema.org/dynamic-resolution-ignores-anchors/root#/items`
 
 
 ## A $dynamicRef that initially resolves to a schema with a matching $dynamicAnchor resolves to the first $dynamicAnchor in the dynamic scope
@@ -494,7 +494,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at https://test.json-schema.org/dynamic-ref-leaving-dynamic-scope/main#`
+ * `[requireValidation] type should be specified at #`
 
 
 ## strict-tree schema, guards against misspelled properties

--- a/doc/samples/draft-next/id.md
+++ b/doc/samples/draft-next/id.md
@@ -1356,7 +1356,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at https://localhost:1234/draft-next/id/my_identifier.json#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #`
 
 
 ## non-schema object containing an $id property

--- a/doc/samples/draft-next/items.md
+++ b/doc/samples/draft-next/items.md
@@ -147,7 +147,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireValidation] additionalProperties or unevaluatedProperties should be specified at #`
+ * `[requireValidation] additionalProperties or unevaluatedProperties should be specified at #/0`
 
 
 ## nested items

--- a/doc/samples/draft-next/ref.md
+++ b/doc/samples/draft-next/ref.md
@@ -240,7 +240,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireValidation] items rule should be specified at #`
+ * `[requireValidation] items rule should be specified at #/properties/foo`
 
 
 ## remote ref, containing refs itself
@@ -736,7 +736,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/$ref`
 
 
 ## $ref to boolean schema true
@@ -927,7 +927,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireValidation] type should be specified at #`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/prop1`
 
 
 ## naive replacement of $ref with its destination is not correct
@@ -1134,7 +1134,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireValidation] type should be specified at https://example.com/draft/next/ref-and-id1/base.json#`
+ * `[requireValidation] type should be specified at #`
 
 
 ## order of evaluation: $id and $anchor and $ref
@@ -1181,7 +1181,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireValidation] type should be specified at https://example.com/draft/next/ref-and-id2/base.json#`
+ * `[requireValidation] type should be specified at #`
 
 
 ## simple URN base URI with $ref via the URN
@@ -1258,7 +1258,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:uuid:deadbeef-1234-00ff-ff00-4321feebdaed#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## URN base URI with NSS
@@ -1296,7 +1296,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:example:1/406/47452/2#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## URN base URI with r-component
@@ -1334,7 +1334,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:example:foo-bar-baz-qux?+CCResolve:cc=uk#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## URN base URI with q-component
@@ -1372,7 +1372,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:example:weather?=op=map&lat=39.56&lon=-104.85&datetime=1969-07-21T02:56:15Z#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## URN base URI with f-component
@@ -1847,7 +1847,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:uuid:deadbeef-1234-0000-0000-4321feebdaed#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## URN base URI with URN and anchor ref
@@ -1886,7 +1886,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## URN ref with nested pointer ref
@@ -1927,7 +1927,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #`
 
 
 ## ref to if
@@ -2061,7 +2061,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at http://example.com/ref/absref.json#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #`
 
 
 ## $id with file URI still resolves pointers - *nix

--- a/doc/samples/draft2019-09/anchor.md
+++ b/doc/samples/draft2019-09/anchor.md
@@ -177,7 +177,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at http://localhost:1234/draft2019-09/child1#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #`
 
 
 ## non-schema object containing an $anchor property

--- a/doc/samples/draft2019-09/id.md
+++ b/doc/samples/draft2019-09/id.md
@@ -1272,7 +1272,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at https://localhost:1234/draft2019-09/id/my_identifier.json#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #`
 
 
 ## non-schema object containing an $id property

--- a/doc/samples/draft2019-09/items.md
+++ b/doc/samples/draft2019-09/items.md
@@ -206,7 +206,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireValidation] additionalProperties or unevaluatedProperties should be specified at #`
+ * `[requireValidation] additionalProperties or unevaluatedProperties should be specified at #/0`
 
 
 ## nested items

--- a/doc/samples/draft2019-09/ref.md
+++ b/doc/samples/draft2019-09/ref.md
@@ -240,7 +240,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireValidation] items rule should be specified at #`
+ * `[requireValidation] items rule should be specified at #/properties/foo`
 
 
 ## remote ref, containing refs itself
@@ -708,7 +708,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/$ref`
 
 
 ## $ref to boolean schema true
@@ -899,7 +899,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireValidation] type should be specified at #`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/prop1`
 
 
 ## naive replacement of $ref with its destination is not correct
@@ -1106,7 +1106,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireValidation] type should be specified at https://example.com/draft2019-09/ref-and-id1/base.json#`
+ * `[requireValidation] type should be specified at #`
 
 
 ## order of evaluation: $id and $anchor and $ref
@@ -1153,7 +1153,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireValidation] type should be specified at https://example.com/draft2019-09/ref-and-id2/base.json#`
+ * `[requireValidation] type should be specified at #`
 
 
 ## simple URN base URI with $ref via the URN
@@ -1230,7 +1230,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:uuid:deadbeef-1234-00ff-ff00-4321feebdaed#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## URN base URI with NSS
@@ -1268,7 +1268,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:example:1/406/47452/2#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## URN base URI with r-component
@@ -1306,7 +1306,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:example:foo-bar-baz-qux?+CCResolve:cc=uk#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## URN base URI with q-component
@@ -1344,7 +1344,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:example:weather?=op=map&lat=39.56&lon=-104.85&datetime=1969-07-21T02:56:15Z#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## URN base URI with f-component
@@ -1791,7 +1791,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:uuid:deadbeef-1234-0000-0000-4321feebdaed#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## URN base URI with URN and anchor ref
@@ -1830,7 +1830,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## URN ref with nested pointer ref
@@ -1871,7 +1871,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #`
 
 
 ## ref to if
@@ -2005,7 +2005,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at http://example.com/ref/absref.json#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #`
 
 
 ## $id with file URI still resolves pointers - *nix

--- a/doc/samples/draft2020-12/anchor.md
+++ b/doc/samples/draft2020-12/anchor.md
@@ -177,7 +177,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at http://localhost:1234/draft2020-12/child1#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #`
 
 
 ## non-schema object containing an $anchor property

--- a/doc/samples/draft2020-12/dynamicRef.md
+++ b/doc/samples/draft2020-12/dynamicRef.md
@@ -39,7 +39,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at https://test.json-schema.org/dynamicRef-dynamicAnchor-same-schema/root#`
+ * `[requireValidation] type should be specified at #/items`
 
 
 ## A $dynamicRef to an $anchor in the same schema resource behaves like a normal $ref to an $anchor
@@ -118,7 +118,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at https://test.json-schema.org/ref-dynamicAnchor-same-schema/root#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/items`
 
 
 ## A $dynamicRef resolves to the first $dynamicAnchor still in scope that is encountered when the schema is evaluated
@@ -181,7 +181,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at https://test.json-schema.org/typical-dynamic-resolution/root#`
+ * `[requireValidation] type should be specified at https://test.json-schema.org/typical-dynamic-resolution/root#/items`
 
 
 ## A $dynamicRef without anchor in fragment behaves identical to $ref
@@ -314,7 +314,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at https://test.json-schema.org/dynamic-resolution-with-intermediate-scopes/root#`
+ * `[requireValidation] type should be specified at https://test.json-schema.org/dynamic-resolution-with-intermediate-scopes/root#/items`
 
 
 ## An $anchor with the same name as a $dynamicAnchor is not used for dynamic scope resolution
@@ -372,7 +372,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireValidation] type should be specified at https://test.json-schema.org/dynamic-resolution-ignores-anchors/list#`
+ * `[requireValidation] type should be specified at https://test.json-schema.org/dynamic-resolution-ignores-anchors/root#/items`
 
 
 ## A $dynamicRef without a matching $dynamicAnchor in the same schema resource behaves like a normal $ref to $anchor
@@ -741,7 +741,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireValidation] type should be specified at https://test.json-schema.org/dynamic-ref-with-multiple-paths/genericList#`
+ * `[requireValidation] type should be specified at https://test.json-schema.org/dynamic-ref-with-multiple-paths/main#/properties/list/items`
 
 
 ## after leaving a dynamic scope, it is not used by a $dynamicRef
@@ -830,7 +830,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at https://test.json-schema.org/dynamic-ref-leaving-dynamic-scope/main#`
+ * `[requireValidation] type should be specified at #`
 
 
 ## strict-tree schema, guards against misspelled properties

--- a/doc/samples/draft2020-12/id.md
+++ b/doc/samples/draft2020-12/id.md
@@ -1356,7 +1356,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at https://localhost:1234/draft2020-12/id/my_identifier.json#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #`
 
 
 ## non-schema object containing an $id property

--- a/doc/samples/draft2020-12/items.md
+++ b/doc/samples/draft2020-12/items.md
@@ -147,7 +147,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireValidation] additionalProperties or unevaluatedProperties should be specified at #`
+ * `[requireValidation] additionalProperties or unevaluatedProperties should be specified at #/0`
 
 
 ## nested items

--- a/doc/samples/draft2020-12/ref.md
+++ b/doc/samples/draft2020-12/ref.md
@@ -240,7 +240,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireValidation] items rule should be specified at #`
+ * `[requireValidation] items rule should be specified at #/properties/foo`
 
 
 ## remote ref, containing refs itself
@@ -736,7 +736,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/$ref`
 
 
 ## $ref to boolean schema true
@@ -927,7 +927,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireValidation] type should be specified at #`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/prop1`
 
 
 ## naive replacement of $ref with its destination is not correct
@@ -1134,7 +1134,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireValidation] type should be specified at https://example.com/draft2020-12/ref-and-id1/base.json#`
+ * `[requireValidation] type should be specified at #`
 
 
 ## order of evaluation: $id and $anchor and $ref
@@ -1181,7 +1181,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireValidation] type should be specified at https://example.com/draft2020-12/ref-and-id2/base.json#`
+ * `[requireValidation] type should be specified at #`
 
 
 ## simple URN base URI with $ref via the URN
@@ -1258,7 +1258,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:uuid:deadbeef-1234-00ff-ff00-4321feebdaed#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## URN base URI with NSS
@@ -1296,7 +1296,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:example:1/406/47452/2#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## URN base URI with r-component
@@ -1334,7 +1334,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:example:foo-bar-baz-qux?+CCResolve:cc=uk#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## URN base URI with q-component
@@ -1372,7 +1372,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:example:weather?=op=map&lat=39.56&lon=-104.85&datetime=1969-07-21T02:56:15Z#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## URN base URI with f-component
@@ -1847,7 +1847,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:uuid:deadbeef-1234-0000-0000-4321feebdaed#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## URN base URI with URN and anchor ref
@@ -1886,7 +1886,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## URN ref with nested pointer ref
@@ -1927,7 +1927,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #`
 
 
 ## ref to if
@@ -2061,7 +2061,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at http://example.com/ref/absref.json#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #`
 
 
 ## $id with file URI still resolves pointers - *nix

--- a/doc/samples/draft4/id.md
+++ b/doc/samples/draft4/id.md
@@ -62,5 +62,5 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at https://localhost:1234/my_identifier.json#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #`
 

--- a/doc/samples/draft4/items.md
+++ b/doc/samples/draft4/items.md
@@ -130,7 +130,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireValidation] additionalProperties or unevaluatedProperties should be specified at #`
+ * `[requireValidation] additionalProperties or unevaluatedProperties should be specified at #/0`
 
 
 ## nested items

--- a/doc/samples/draft4/ref.md
+++ b/doc/samples/draft4/ref.md
@@ -639,7 +639,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/$ref`
 
 
 ## Recursive references between schemas

--- a/doc/samples/draft6/id.md
+++ b/doc/samples/draft6/id.md
@@ -65,7 +65,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at https://localhost:1234/id/my_identifier.json#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #`
 
 
 ## non-schema object containing a plain-name $id property

--- a/doc/samples/draft6/items.md
+++ b/doc/samples/draft6/items.md
@@ -209,7 +209,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireValidation] additionalProperties or unevaluatedProperties should be specified at #`
+ * `[requireValidation] additionalProperties or unevaluatedProperties should be specified at #/0`
 
 
 ## nested items

--- a/doc/samples/draft6/ref.md
+++ b/doc/samples/draft6/ref.md
@@ -635,7 +635,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/$ref`
 
 
 ## $ref to boolean schema true
@@ -1086,7 +1086,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:uuid:deadbeef-1234-00ff-ff00-4321feebdaed#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## URN base URI with NSS
@@ -1124,7 +1124,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:example:1/406/47452/2#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## URN base URI with r-component
@@ -1162,7 +1162,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:example:foo-bar-baz-qux?+CCResolve:cc=uk#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## URN base URI with q-component
@@ -1200,7 +1200,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:example:weather?=op=map&lat=39.56&lon=-104.85&datetime=1969-07-21T02:56:15Z#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## URN base URI with URN and JSON pointer ref
@@ -1241,7 +1241,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:uuid:deadbeef-1234-0000-0000-4321feebdaed#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## URN base URI with URN and anchor ref
@@ -1280,7 +1280,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## ref with absolute-path-reference
@@ -1318,7 +1318,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at http://example.com/ref/absref.json#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #`
 
 
 ## $id with file URI still resolves pointers - *nix

--- a/doc/samples/draft7/id.md
+++ b/doc/samples/draft7/id.md
@@ -65,7 +65,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at https://localhost:1234/id/my_identifier.json#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #`
 
 
 ## non-schema object containing a plain-name $id property

--- a/doc/samples/draft7/items.md
+++ b/doc/samples/draft7/items.md
@@ -209,7 +209,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireValidation] additionalProperties or unevaluatedProperties should be specified at #`
+ * `[requireValidation] additionalProperties or unevaluatedProperties should be specified at #/0`
 
 
 ## nested items

--- a/doc/samples/draft7/ref.md
+++ b/doc/samples/draft7/ref.md
@@ -662,7 +662,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/$ref`
 
 
 ## $ref to boolean schema true
@@ -1146,7 +1146,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:uuid:deadbeef-1234-00ff-ff00-4321feebdaed#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## URN base URI with NSS
@@ -1184,7 +1184,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:example:1/406/47452/2#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## URN base URI with r-component
@@ -1222,7 +1222,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:example:foo-bar-baz-qux?+CCResolve:cc=uk#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## URN base URI with q-component
@@ -1260,7 +1260,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:example:weather?=op=map&lat=39.56&lon=-104.85&datetime=1969-07-21T02:56:15Z#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## URN base URI with URN and JSON pointer ref
@@ -1301,7 +1301,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:uuid:deadbeef-1234-0000-0000-4321feebdaed#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## URN base URI with URN and anchor ref
@@ -1340,7 +1340,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #/properties/foo`
 
 
 ## ref to if
@@ -1480,7 +1480,7 @@ return ref0
 
 ##### Strong mode notices
 
- * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at http://example.com/ref/absref.json#`
+ * `[requireStringValidation] pattern, format or contentSchema should be specified for strings, use pattern: ^[\s\S]*$ to opt-out at #`
 
 
 ## $id with file URI still resolves pointers - *nix

--- a/test/regressions/strong-refs.js
+++ b/test/regressions/strong-refs.js
@@ -106,3 +106,641 @@ tape('cyclic ref passes if fully covers the object', (t) => {
 
   t.end()
 })
+
+tape('partially validating local ref can be used (objects)', (t) => {
+  const propTwoBare = { properties: { two: { const: 2 } }, required: ['two'] }
+  const propTwoFull = { ...propTwoBare, type: 'object' }
+  const compile = (schema) =>
+    validator(
+      {
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        ...schema,
+      },
+      { mode: 'strong' }
+    )
+
+  t.throws(() => compile(propTwoBare), /\[requireValidation\] type should be specified/)
+  t.throws(() => compile(propTwoFull), /\[requireValidation\].*Properties should be specified/)
+
+  t.throws(() => {
+    compile(
+      {
+        $ref: '#/$defs/propTwo',
+        $defs: {
+          propTwo: propTwoBare,
+        },
+        // type: 'object',
+        unevaluatedProperties: false,
+      },
+      { mode: 'strong' }
+    )
+  })
+  t.throws(() => {
+    compile(
+      {
+        $ref: '#/$defs/propTwo',
+        $defs: {
+          propTwo: propTwoBare,
+        },
+        type: 'object',
+        // unevaluatedProperties: false,
+      },
+      { mode: 'strong' }
+    )
+  })
+  t.doesNotThrow(() => {
+    const validate = compile({
+      $ref: '#/$defs/propTwo',
+      $defs: {
+        propTwo: propTwoBare,
+      },
+      type: 'object',
+      unevaluatedProperties: false,
+    })
+    t.notOk(validate({}), '{}')
+    t.ok(validate({ two: 2 }), '{two:2}')
+    t.notOk(validate({ three: 2 }), '{three:2}')
+    t.notOk(validate({ two: 3 }), '{two:3}')
+    t.notOk(validate({ two: 2, three: 3 }), '{two:2, three:3}')
+    t.notOk(validate({ two: 2, one: 1 }), '{two:2, one:1}')
+    t.notOk(validate({ one: 1 }), '{one:1}')
+  })
+  t.doesNotThrow(() => {
+    const validate = compile({
+      $ref: '#/$defs/propTwo',
+      $defs: {
+        propTwo: propTwoFull,
+      },
+      unevaluatedProperties: false,
+    })
+    t.notOk(validate({}), '{}')
+    t.ok(validate({ two: 2 }), '{two:2}')
+    t.notOk(validate({ three: 2 }), '{three:2}')
+    t.notOk(validate({ two: 3 }), '{two:3}')
+    t.notOk(validate({ two: 2, three: 3 }), '{two:2, three:3}')
+    t.notOk(validate({ two: 2, one: 1 }), '{two:2, one:1}')
+    t.notOk(validate({ one: 1 }), '{one:1}')
+  })
+  t.doesNotThrow(() => {
+    const validate = compile({
+      $ref: '#/$defs/propTwo',
+      $defs: {
+        propTwo: propTwoBare,
+      },
+      required: [],
+      properties: {
+        one: { const: 1 },
+      },
+      type: 'object',
+      unevaluatedProperties: false,
+    })
+    t.notOk(validate({}), '{}')
+    t.ok(validate({ two: 2 }), '{two:2}')
+    t.notOk(validate({ three: 2 }), '{three:2}')
+    t.notOk(validate({ two: 3 }), '{two:3}')
+    t.notOk(validate({ two: 2, three: 3 }), '{two:2, three:3}')
+    t.ok(validate({ two: 2, one: 1 }), '{two:2, one:1}')
+    t.notOk(validate({ one: 1 }), '{one:1}')
+  })
+  t.doesNotThrow(() => {
+    const validate = compile({
+      $ref: '#/$defs/propTwo',
+      $defs: {
+        propTwo: propTwoFull,
+      },
+      required: [],
+      properties: {
+        one: { const: 1 },
+      },
+      unevaluatedProperties: false,
+    })
+    t.notOk(validate({}), '{}')
+    t.ok(validate({ two: 2 }), '{two:2}')
+    t.notOk(validate({ three: 2 }), '{three:2}')
+    t.notOk(validate({ two: 3 }), '{two:3}')
+    t.notOk(validate({ two: 2, three: 3 }), '{two:2, three:3}')
+    t.ok(validate({ two: 2, one: 1 }), '{two:2, one:1}')
+    t.notOk(validate({ one: 1 }), '{one:1}')
+  })
+
+  t.end()
+})
+
+tape('partially validating local ref can be used (strings)', (t) => {
+  const stringDateBare = { format: 'date' }
+  const stringDateFull = { ...stringDateBare, type: 'string' }
+  const compile = (schema) =>
+    validator(
+      {
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        ...schema,
+      },
+      { mode: 'strong' }
+    )
+
+  t.throws(() => compile(stringDateBare), /\[requireValidation\] type should be specified/)
+  t.doesNotThrow(() => compile(stringDateFull))
+
+  t.throws(() => {
+    compile(
+      {
+        $ref: '#/$defs/stringDate',
+        $defs: {
+          stringDate: stringDateBare,
+        },
+        // type: 'string',
+      },
+      { mode: 'strong' }
+    )
+  })
+  t.doesNotThrow(() => {
+    const validate = compile({
+      $ref: '#/$defs/stringDate',
+      $defs: {
+        stringDate: stringDateBare,
+      },
+      type: 'string',
+    })
+    t.notOk(validate(''), '""')
+    t.notOk(validate('abc'), '"abc"')
+    t.ok(validate('2000-01-01'), '"2000-01-01"')
+  })
+  t.doesNotThrow(() => {
+    const validate = compile({
+      $ref: '#/$defs/stringDate',
+      $defs: {
+        stringDate: stringDateFull,
+      },
+    })
+    t.notOk(validate(''), '""')
+    t.notOk(validate('abc'), '"abc"')
+    t.ok(validate('2000-01-01'), '"2000-01-01"')
+  })
+  t.end()
+})
+
+tape('cyclic local refs do full validation', (t) => {
+  const compile = ($defs) =>
+    validator(
+      {
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        $defs,
+        $ref: '#/$defs/A',
+      },
+      { mode: 'strong' }
+    )
+
+  t.throws(() => {
+    compile({
+      A: {
+        type: ['array'],
+      },
+    })
+  })
+
+  t.throws(() => {
+    compile({
+      A: {
+        type: ['array', 'object'],
+        items: {
+          $ref: '#/$defs/A',
+        },
+      },
+    })
+  })
+
+  t.doesNotThrow(() => {
+    const validate = compile({
+      A: {
+        type: ['array'],
+        items: {
+          $ref: '#/$defs/A',
+        },
+      },
+    })
+    t.notOk(validate({}), '{}')
+    t.ok(validate([]), '[]')
+    t.ok(validate([[]]), '[[]]')
+    t.ok(validate([[[]]]), '[[[]]]')
+    t.notOk(validate([1]), '[1]')
+    t.notOk(validate([{}]), '[{}]')
+  })
+
+  t.throws(() => {
+    compile({
+      A: {
+        type: ['array'],
+        prefixItems: [{ $ref: '#/$defs/A' }],
+      },
+    })
+  })
+
+  t.doesNotThrow(() => {
+    const validate = compile({
+      A: {
+        type: ['array', 'object'],
+        oneOf: [
+          {
+            type: 'array',
+            items: {
+              $ref: '#/$defs/A',
+            },
+          },
+          {
+            type: 'object',
+            required: [],
+            additionalProperties: false,
+            properties: {
+              x: { $ref: '#/$defs/A' },
+            },
+          },
+        ],
+      },
+    })
+    t.ok(validate({}), '{}')
+    t.ok(validate([]), '[]')
+    t.ok(validate([[]]), '[[]]')
+    t.ok(validate([[[]]]), '[[[]]]')
+    t.notOk(validate([1]), '[1]')
+    t.ok(validate([{}]), '[{}]')
+  })
+
+  t.throws(() => {
+    compile({
+      A: {
+        type: ['array', 'object'],
+        oneOf: [
+          {
+            type: 'array',
+            items: {
+              $ref: '#/$defs/B',
+            },
+          },
+          {
+            type: 'object',
+            required: [],
+            additionalProperties: false,
+            properties: {
+              x: { $ref: '#/$defs/B' },
+            },
+          },
+        ],
+      },
+      B: {
+        type: ['array', 'object'],
+        oneOf: [
+          {
+            type: 'array',
+          },
+          {
+            type: 'object',
+            required: [],
+            additionalProperties: false,
+            properties: {
+              x: { $ref: '#/$defs/A' },
+            },
+          },
+        ],
+      },
+    })
+  })
+
+  t.throws(() => {
+    compile({
+      A: {
+        type: ['array', 'object'],
+        oneOf: [
+          {
+            type: 'array',
+            prefixItems: [{ $ref: '#/$defs/A' }],
+          },
+          {
+            type: 'object',
+            required: [],
+            additionalProperties: false,
+            properties: {
+              x: { $ref: '#/$defs/A' },
+            },
+          },
+        ],
+      },
+    })
+  })
+
+  t.doesNotThrow(() => {
+    const validate = compile({
+      A: {
+        type: ['array', 'object'],
+        oneOf: [
+          {
+            type: 'array',
+            items: {
+              $ref: '#/$defs/B',
+            },
+          },
+          {
+            type: 'object',
+            required: [],
+            additionalProperties: false,
+            properties: {
+              x: { $ref: '#/$defs/B' },
+            },
+          },
+        ],
+      },
+      B: {
+        type: ['array', 'object'],
+        oneOf: [
+          {
+            type: 'array',
+            items: {
+              $ref: '#/$defs/A',
+            },
+          },
+          {
+            type: 'object',
+            required: [],
+            additionalProperties: false,
+            properties: {
+              x: { $ref: '#/$defs/A' },
+            },
+          },
+        ],
+      },
+    })
+    t.ok(validate({}), '{}')
+    t.ok(validate([]), '[]')
+    t.ok(validate([[]]), '[[]]')
+    t.ok(validate([[[]]]), '[[[]]]')
+    t.notOk(validate([1]), '[1]')
+    t.ok(validate([{}]), '[{}]')
+  })
+
+  t.throws(() => {
+    compile({
+      A: {
+        type: ['array', 'object'],
+        oneOf: [
+          {
+            type: 'array',
+            prefixItems: [{ $ref: '#/$defs/B' }],
+          },
+          {
+            type: 'object',
+            required: [],
+            additionalProperties: false,
+            properties: {
+              x: { $ref: '#/$defs/B' },
+            },
+          },
+        ],
+      },
+      B: {
+        type: ['array', 'object'],
+        oneOf: [
+          {
+            type: 'array',
+            items: {
+              $ref: '#/$defs/A',
+            },
+          },
+          {
+            type: 'object',
+            required: [],
+            additionalProperties: false,
+            properties: {
+              x: { $ref: '#/$defs/A' },
+            },
+          },
+        ],
+      },
+    })
+  })
+
+  t.throws(() => {
+    compile({
+      A: {
+        type: ['array', 'object'],
+        oneOf: [
+          {
+            type: 'array',
+            items: {
+              $ref: '#/$defs/B',
+            },
+          },
+          {
+            type: 'object',
+            required: [],
+            additionalProperties: false,
+            properties: {
+              x: { $ref: '#/$defs/B' },
+            },
+          },
+        ],
+      },
+      B: {
+        type: ['array', 'object'],
+        oneOf: [
+          {
+            type: 'array',
+            prefixItems: [{ $ref: '#/$defs/A' }],
+          },
+          {
+            type: 'object',
+            required: [],
+            additionalProperties: false,
+            properties: {
+              x: { $ref: '#/$defs/A' },
+            },
+          },
+        ],
+      },
+    })
+  })
+
+  t.end()
+})
+
+tape('cyclic local refs do full string validation: !Validation, StringValidation', (t) => {
+  const compile = ($defs) =>
+    validator(
+      {
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        $defs,
+        $ref: '#/$defs/A',
+      },
+      { requireValidation: false, requireStringValidation: true }
+    )
+
+  t.doesNotThrow(() => {
+    compile({
+      A: {
+        type: ['array'],
+      },
+    })
+  })
+
+  t.throws(() => {
+    compile({
+      A: {
+        type: ['string'],
+      },
+    })
+  })
+
+  t.throws(() => {
+    compile({
+      A: {
+        type: ['array', 'string'],
+        oneOf: [
+          {
+            type: 'array',
+            items: {
+              $ref: '#/$defs/A',
+            },
+          },
+          {
+            type: 'string',
+          },
+        ],
+      },
+    })
+  })
+
+  t.doesNotThrow(() => {
+    const validate = compile({
+      A: {
+        type: ['array', 'string'],
+        oneOf: [
+          {
+            type: 'array',
+            items: {
+              $ref: '#/$defs/A',
+            },
+          },
+          {
+            type: 'string',
+            format: 'date',
+          },
+        ],
+      },
+    })
+    t.notOk(validate({}), '{}')
+    t.ok(validate([]), '[]')
+    t.ok(validate([[]]), '[[]]')
+    t.ok(validate([[[]]]), '[[[]]]')
+    t.notOk(validate(['']), '[""]')
+    t.ok(validate(['2000-01-01']), '["2000-01-01"]')
+  })
+
+  t.throws(() => {
+    compile({
+      A: {
+        type: ['array', 'string'],
+        oneOf: [
+          {
+            type: 'array',
+            items: {
+              $ref: '#/$defs/B',
+            },
+          },
+          {
+            type: 'string',
+            format: 'date',
+          },
+        ],
+      },
+      B: {
+        type: ['array', 'string'],
+        oneOf: [
+          {
+            type: 'array',
+            items: {
+              $ref: '#/$defs/A',
+            },
+          },
+          {
+            type: 'string',
+          },
+        ],
+      },
+    })
+  })
+
+  t.throws(() => {
+    compile({
+      A: {
+        type: ['array', 'string'],
+        oneOf: [
+          {
+            type: 'array',
+            items: {
+              $ref: '#/$defs/B',
+            },
+          },
+          {
+            type: 'string',
+          },
+        ],
+      },
+      B: {
+        type: ['array', 'string'],
+        oneOf: [
+          {
+            type: 'array',
+            items: {
+              $ref: '#/$defs/A',
+            },
+          },
+          {
+            type: 'string',
+            format: 'date',
+          },
+        ],
+      },
+    })
+  })
+
+  t.doesNotThrow(() => {
+    const validate = compile({
+      A: {
+        type: ['array', 'string'],
+        oneOf: [
+          {
+            type: 'array',
+            items: {
+              $ref: '#/$defs/B',
+            },
+          },
+          {
+            type: 'string',
+            format: 'date',
+          },
+        ],
+      },
+      B: {
+        type: ['array', 'string'],
+        oneOf: [
+          {
+            type: 'array',
+            items: {
+              $ref: '#/$defs/A',
+            },
+          },
+          {
+            type: 'string',
+            format: 'date',
+          },
+        ],
+      },
+    })
+    t.notOk(validate({}), '{}')
+    t.ok(validate([]), '[]')
+    t.ok(validate([[]]), '[[]]')
+    t.ok(validate([[[]]]), '[[[]]]')
+    t.notOk(validate(['']), '[""]')
+    t.ok(validate(['2000-01-01']), '["2000-01-01"]')
+  })
+
+  t.end()
+})


### PR DESCRIPTION
Refs: https://github.com/ExodusMovement/schemasafe/issues/161#issuecomment-1670111982

This will allow e.g. this to compile in strong mode:
```js
  {
    $schema: 'https://json-schema.org/draft/2020-12/schema',
    allOf: [
      {
        $ref: '#/definitions/base',
      },
    ],
    definitions: {
      base: {
        required: [],
        properties: {
          version: {
            const: '2',
          },
        },
        type: 'object',
       //  unevaluatedProperties: false,
      },
    },
    properties: {
      type: {
        const: 'acknowledge',
      },
    },
    required: ['type'],
    type: 'object',
    unevaluatedProperties: false,
  }
```