### PR TITLE
fix: we are sure about type if parent checked it

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -1284,7 +1284,10 @@ const compileSchema = (schema, root, opts, scope, basePathRoot = '') => {
           evaluateDelta({ type: [current.type] })
           return null
         }
-        if (parentCheckedType(...typearr)) return null
+        if (parentCheckedType(...typearr)) {
+          evaluateDelta({ type: typearr })
+          return null
+        }
         const filteredTypes = typearr.filter((t) => typeApplicable(t))
         if (filteredTypes.length === 0) fail('No valid types possible')
         evaluateDelta({ type: typearr }) // can be safely done here, filteredTypes already prepared

--- a/test/regressions/177.js
+++ b/test/regressions/177.js
@@ -1,0 +1,78 @@
+'use strict'
+
+const tape = require('tape')
+const { validator } = require('../../')
+
+tape('regression #177', (t) => {
+  const variants = [{ type: 'object' }, {}]
+
+  for (const l0 of variants) {
+    for (const l1a of variants) {
+      for (const l1b of variants) {
+        for (const l2a of variants) {
+          for (const l2b of variants) {
+            if (!l0.type && !l1a.type) continue
+            if (!l0.type && !l1b.type && !l2a.type) continue
+            if (!l0.type && !l1b.type && !l2b.type) continue
+
+            if (l0.type && (!l2a.type || !l2b.type)) continue // Bug, fixed by #179
+
+            t.doesNotThrow(() => {
+              const validate = validator({
+                required: ['type'],
+                discriminator: { propertyName: 'type' },
+                ...l0,
+                properties: {
+                  type: {
+                    enum: ['noop', 'foo'],
+                  },
+                },
+                oneOf: [
+                  {
+                    ...l1a,
+                    properties: { type: { const: 'noop' } },
+                  },
+                  {
+                    ...l1b,
+                    required: ['method'],
+                    discriminator: { propertyName: 'method' },
+                    properties: {
+                      type: { const: 'foo' },
+                      method: {
+                        enum: ['bar', 'buzz'],
+                      },
+                    },
+                    oneOf: [
+                      {
+                        ...l2a,
+                        properties: {
+                          method: { const: 'bar' },
+                        },
+                      },
+                      {
+                        ...l2b,
+                        properties: {
+                          method: { const: 'buzz' },
+                        },
+                      },
+                    ],
+                  },
+                ],
+              })
+
+              t.notOk(validate({}), '{}')
+              t.ok(validate({ type: 'noop' }), "{ type: 'noop' }")
+              t.notOk(validate({ type: 'no' }), "{ type: 'no' }")
+              t.notOk(validate({ type: 'bar' }), "{ type: 'bar' }")
+              t.notOk(validate({ type: 'foo' }), "{ type: 'foo' }")
+              t.ok(validate({ type: 'foo', method: 'bar' }), "{ type: 'foo', method: 'bar' }")
+              t.notOk(validate({ type: 'foo', method: 'fuzz' }), "{ type: 'foo', method: 'fuzz' }")
+            }, JSON.stringify([l0, l1a, l1b, l2a, l2b]))
+          }
+        }
+      }
+    }
+  }
+
+  t.end()
+})


### PR DESCRIPTION
Type delta calculation here is needed for discriminator to be sure that we can compile.

Fixes: #176. 

This is just the first part of the fix that will work if `type: object` is specified on levels 1 and 2 or level 3.

An additional fix is needed to allow specifying `type: object` only once on level 1.

See also explanation in https://github.com/ExodusMovement/schemasafe/issues/176#issuecomment-1910259508